### PR TITLE
feat(coding-agent): dynamic workflows + loop as the first consumer

### DIFF
--- a/apps/backend/drizzle/backend/0031_workflow_budget.sql
+++ b/apps/backend/drizzle/backend/0031_workflow_budget.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agent_run ADD COLUMN workflow_budget_tokens integer;
+--> statement-breakpoint
+ALTER TABLE branch_input_queue ADD COLUMN workflow_budget_tokens integer;

--- a/apps/backend/drizzle/backend/meta/_journal.json
+++ b/apps/backend/drizzle/backend/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1786605000000,
       "tag": "0030_run_todo",
       "breakpoints": false
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1786606000000,
+      "tag": "0031_workflow_budget",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -27,6 +27,7 @@
     "@my-agent-team/adapter-pi-agent": "workspace:*",
     "@my-agent-team/adapter-claude-agent": "workspace:*",
     "@my-agent-team/agent-backend": "workspace:*",
+    "@my-agent-team/ai": "workspace:*",
     "@my-agent-team/api-contract": "workspace:*",
     "@my-agent-team/config": "workspace:*",
     "@my-agent-team/conversation": "workspace:*",

--- a/apps/backend/src/bootstrap/features.ts
+++ b/apps/backend/src/bootstrap/features.ts
@@ -262,9 +262,12 @@ export async function installFeatures(services: BackendServices): Promise<Instal
       const identity = await identityStore.getIdentity(agentId);
       const systemPrompt = buildAgentSystemPrompt(identity.soul, identity.user);
       const packs = await skillPackPort.listForAgent(agentId);
-      const skillRoots = packs
+      const packRoots = packs
         .filter((p) => p.status === "ready")
         .map((p) => installPath(config.dataDir, p.id));
+      // The builtin skills (capability docs: workflow authoring, loop
+      // workflow) are ALWAYS available - assigned packs add on top.
+      const skillRoots = [config.builtinSkillsDir, ...packRoots];
       const result: {
         systemPrompt?: string;
         skillRoots?: readonly string[];

--- a/apps/backend/src/features/agent-run/adapter-sqlite.ts
+++ b/apps/backend/src/features/agent-run/adapter-sqlite.ts
@@ -57,6 +57,7 @@ function parseRun(row: typeof schema.agentRun.$inferSelect): AgentRun {
     skillRoots: row.skillRoots ? (JSON.parse(row.skillRoots) as string[]) : null,
     permissionMode: row.permissionMode,
     todoSnapshot: row.todoSnapshot,
+    workflowBudgetTokens: row.workflowBudgetTokens,
     createdAt: row.createdAt,
     terminalAt: row.terminalAt,
   };
@@ -85,6 +86,7 @@ function parseInput(row: typeof schema.branchInputQueue.$inferSelect): BranchInp
       systemPrompt: row.systemPrompt,
       skillRoots: row.skillRoots ? (JSON.parse(row.skillRoots) as string[]) : null,
       permissionMode: row.permissionMode,
+      workflowBudgetTokens: row.workflowBudgetTokens,
     },
     createdAt: row.createdAt,
     deliveredAt: row.deliveredAt,
@@ -147,6 +149,7 @@ export function sqliteAgentRunAdapter(db: Database, deps: AgentRunAdapterDeps): 
               systemPrompt: command.systemPrompt ?? null,
               skillRoots: command.skillRoots ? JSON.stringify(command.skillRoots) : null,
               permissionMode: command.permissionMode ?? null,
+              workflowBudgetTokens: command.workflowBudgetTokens ?? null,
               createdAt: now,
             })
             .run();
@@ -531,6 +534,7 @@ export function sqliteAgentRunAdapter(db: Database, deps: AgentRunAdapterDeps): 
             systemPrompt: snapshot.systemPrompt ?? null,
             skillRoots: snapshot.skillRoots ? JSON.stringify(snapshot.skillRoots) : null,
             permissionMode: snapshot.permissionMode ?? null,
+            workflowBudgetTokens: snapshot.workflowBudgetTokens ?? null,
             createdAt: now,
           })
           .run();

--- a/apps/backend/src/features/agent-run/domain.ts
+++ b/apps/backend/src/features/agent-run/domain.ts
@@ -60,6 +60,8 @@ export interface AgentRun {
   readonly permissionMode: string | null;
   /** JSON: latest task list snapshot (todo_write product tool). */
   readonly todoSnapshot: string | null;
+  /** Optional workflow budget (tokens), frozen at Run creation. */
+  readonly workflowBudgetTokens: number | null;
   readonly createdAt: number;
   readonly terminalAt: number | null;
 }
@@ -91,6 +93,7 @@ export interface BranchInput {
     readonly systemPrompt: string | null;
     readonly skillRoots: readonly string[] | null;
     readonly permissionMode: string | null;
+    readonly workflowBudgetTokens: number | null;
   };
   readonly createdAt: number;
   readonly deliveredAt: number | null;
@@ -137,6 +140,8 @@ export interface AcquireAgentRunCommand {
   readonly skillRoots?: readonly string[];
   /** Frozen permission_mode (ADR 0020 decision 7). */
   readonly permissionMode?: string;
+  /** Optional workflow budget (tokens) for this Run; null = no gate. */
+  readonly workflowBudgetTokens?: number;
 }
 export interface AcquireAgentRunResult {
   readonly acquired: boolean;

--- a/apps/backend/src/features/agent-run/execution.ts
+++ b/apps/backend/src/features/agent-run/execution.ts
@@ -276,6 +276,7 @@ export function createAgentRunExecutionService(
       skillRoots?: readonly string[];
       cliSessionRef?: string;
       permissionMode?: "ask" | "auto" | "deny";
+      workflowBudgetTokens?: number;
     } = {
       runId: run.runId,
       model: run.modelRef,
@@ -303,10 +304,11 @@ export function createAgentRunExecutionService(
       runSnapshot.systemPrompt = productContext;
     }
     if (run.skillRoots && run.skillRoots.length > 0) runSnapshot.skillRoots = run.skillRoots;
-    if (cliSessionRef) runSnapshot.cliSessionRef = cliSessionRef;
     if (run.permissionMode) {
       runSnapshot.permissionMode = run.permissionMode as "ask" | "auto" | "deny";
     }
+    if (run.workflowBudgetTokens != null)
+      runSnapshot.workflowBudgetTokens = run.workflowBudgetTokens;
     return {
       input: {
         inputId: input.inputId,

--- a/apps/backend/src/features/agent-run/service.ts
+++ b/apps/backend/src/features/agent-run/service.ts
@@ -47,6 +47,8 @@ export interface AgentRunService {
     systemPrompt?: string;
     skillRoots?: readonly string[];
     permissionMode?: string;
+    /** Optional workflow budget (tokens) frozen on the Run. */
+    workflowBudgetTokens?: number;
   }): Promise<{
     acquired: boolean;
     queued: boolean;
@@ -152,6 +154,7 @@ export function createAgentRunService(deps: AgentRunServiceDeps): AgentRunServic
         systemPrompt,
         skillRoots,
         permissionMode,
+        workflowBudgetTokens: input.workflowBudgetTokens,
       });
     },
 

--- a/apps/backend/src/features/cron/scheduler.test.ts
+++ b/apps/backend/src/features/cron/scheduler.test.ts
@@ -65,7 +65,7 @@ function makeRunsFakes(script: {
         skillRoots: null,
         permissionMode: null,
         todoSnapshot: null,
-      workflowBudgetTokens: null,
+        workflowBudgetTokens: null,
         workspace: null,
         createdAt: 0,
         terminalAt: null,

--- a/apps/backend/src/features/cron/scheduler.test.ts
+++ b/apps/backend/src/features/cron/scheduler.test.ts
@@ -65,6 +65,7 @@ function makeRunsFakes(script: {
         skillRoots: null,
         permissionMode: null,
         todoSnapshot: null,
+      workflowBudgetTokens: null,
         workspace: null,
         createdAt: 0,
         terminalAt: null,

--- a/apps/backend/src/features/cron/scheduler.ts
+++ b/apps/backend/src/features/cron/scheduler.ts
@@ -164,6 +164,7 @@ export function createCronScheduler(deps: {
         backendKind: "coding_agent",
         modelId,
       }),
+      builtinSkillsDir: deps.config.builtinSkillsDir,
     };
     let attempt = 0;
     let currentJob = job;

--- a/apps/backend/src/features/loop/http.ts
+++ b/apps/backend/src/features/loop/http.ts
@@ -21,7 +21,7 @@ import {
   runLoop,
 } from "./loop-service.js";
 import type { LoopStateStore } from "./loop-state-store.js";
-import { loopEvaluatorConversationId, loopGeneratorConversationId } from "./loop-step.js";
+import { loopGeneratorConversationId } from "./loop-step.js";
 
 export function loopRoutes(input: {
   cronSvc: CronJobService;
@@ -212,7 +212,6 @@ export function loopRoutes(input: {
       // and its terminal commit.
       const active = await agentRunService.hasActiveRunForConversations([
         loopGeneratorConversationId(id),
-        loopEvaluatorConversationId(id),
       ]);
       if (active) {
         throw new ConflictError("Loop has an active run; stop it before deleting.");

--- a/apps/backend/src/features/loop/loop-service.ts
+++ b/apps/backend/src/features/loop/loop-service.ts
@@ -275,6 +275,8 @@ export async function runLoop(
     agentRunService: AgentRunService;
     agentRunExecution: AgentRunExecutionService;
     resolveModel: (modelName: string) => Promise<BackendModelRef>;
+    /** Repo builtin skills dir; forwarded to the Loop step. */
+    builtinSkillsDir?: string;
   },
   id: string,
 ): Promise<LoopState | null> {
@@ -301,6 +303,7 @@ export async function runLoop(
     agentRunService,
     agentRunExecution,
     resolveModel,
+    ...(deps.builtinSkillsDir ? { builtinSkillsDir: deps.builtinSkillsDir } : {}),
   });
 }
 
@@ -320,6 +323,8 @@ export async function reviewLoop(
     agentRunService: AgentRunService;
     agentRunExecution: AgentRunExecutionService;
     resolveModel: (modelName: string) => Promise<BackendModelRef>;
+    /** Repo builtin skills dir; forwarded to the Loop step. */
+    builtinSkillsDir?: string;
   },
   id: string,
   input: ReviewInput,
@@ -352,6 +357,7 @@ export async function reviewLoop(
     agentRunService,
     agentRunExecution,
     resolveModel,
+    ...(deps.builtinSkillsDir ? { builtinSkillsDir: deps.builtinSkillsDir } : {}),
   });
 
   return { state, action: input.verdict };

--- a/apps/backend/src/features/loop/loop-step.test.ts
+++ b/apps/backend/src/features/loop/loop-step.test.ts
@@ -126,9 +126,10 @@ function emptyState(): LoopState {
 
 interface RunScript {
   genStatus?: "completed" | "failed" | "commit_failed";
-  evalStatus?: "completed" | "aborted" | "timeout";
-  /** VERDICT.md content the evaluator "writes". */
-  evalVerdictMd?: string;
+  /** The workflow meta the fake generator "writes back" to
+   *  .workflows/loop.js. undefined = a default PASS meta; null = no file
+   *  (the no-writeback path). */
+  workflowMeta?: Record<string, unknown> | null;
   /** usage tokens returned on both runs. */
   usageTokens?: number;
   /** generator rejects the input (queued behind another run). */
@@ -235,27 +236,31 @@ function makeFakeRuns(script: RunScript, workDir: string = "") {
     async dispatch(runId) {
       const run = runs.get(runId);
       if (!run) return;
-      if (run.agentMemberId.startsWith("loop-evaluator")) {
-        const status = script.evalStatus ?? "completed";
-        (run as { status: AgentRun["status"] }).status = status;
-        if (script.evalVerdictMd !== undefined) {
-          await Bun.write(`${workDir}/VERDICT.md`, script.evalVerdictMd);
-        }
-        (run as { terminalResult: BackendRunOutcome | null }).terminalResult = {
-          status: status === "completed" ? "completed" : status,
-          ...(script.usageTokens !== undefined
-            ? { usage: { inputTokens: script.usageTokens, outputTokens: 0 } }
-            : {}),
-        } as BackendRunOutcome;
-      } else {
-        const status = script.genStatus ?? "completed";
-        (run as { status: AgentRun["status"] }).status = status;
-        (run as { terminalResult: BackendRunOutcome | null }).terminalResult = {
-          status: status === "completed" ? "completed" : status,
-          ...(script.usageTokens !== undefined
-            ? { usage: { inputTokens: script.usageTokens, outputTokens: 0 } }
-            : {}),
-        } as BackendRunOutcome;
+      const status = script.genStatus ?? "completed";
+      (run as { status: AgentRun["status"] }).status = status;
+      (run as { terminalResult: BackendRunOutcome | null }).terminalResult = {
+        status: status === "completed" ? "completed" : status,
+        ...(script.usageTokens !== undefined
+          ? { usage: { inputTokens: script.usageTokens, outputTokens: 0 } }
+          : {}),
+      } as BackendRunOutcome;
+      // The fake model writes the workflow meta back to the script file.
+      if (script.workflowMeta !== null) {
+        const meta =
+          script.workflowMeta ??
+          ({
+            "item-1": {
+              id: "item-1",
+              step: "verifying",
+              result: { verdict: "PASS", evidence: "e" },
+            },
+          } as Record<string, unknown>);
+        const dir = `${workDir}/.workflows`;
+        await mkdir(dir, { recursive: true });
+        await Bun.write(
+          `${dir}/loop.js`,
+          `export const meta = ${JSON.stringify({ items: meta })};`,
+        );
       }
     },
     async recover() {},
@@ -279,8 +284,6 @@ function makeFakeRuns(script: RunScript, workDir: string = "") {
 }
 
 const genConversationId = (loopId: string) => `loop:${loopId}:generator`;
-const evalConversationId = (loopId: string) => `loop:${loopId}:evaluator`;
-
 async function runStep(
   overrides: Partial<{
     store: LoopStateStore;
@@ -341,46 +344,45 @@ function stateWithFixingItem(store: LoopStateStore): LoopState {
 }
 
 describe("loopStep — Generator/Evaluator as Agent Runs", () => {
-  test("TICK → generator + evaluator each run on their own stable scope", async () => {
+  test("TICK → one generator run on its stable scope (no evaluator scope)", async () => {
     const store = createTestStore();
     stateWithFixingItem(store);
-    const { enqueues } = await runStep({
-      store,
-      script: { evalVerdictMd: "verdict: PASS\nevidence: ok" },
-    });
+    const { enqueues } = await runStep({ store });
 
     const gen = enqueues.find((e) => e.agentMemberId.startsWith("loop-generator"));
-    const eva = enqueues.find((e) => e.agentMemberId.startsWith("loop-evaluator"));
     expect(gen).toBeTruthy();
-    expect(eva).toBeTruthy();
-    // independent deterministic identities
+    expect(enqueues.some((e) => e.agentMemberId.startsWith("loop-evaluator"))).toBe(false);
+    // deterministic generator identity
     expect(gen!.conversationId).toBe(genConversationId("test"));
-    expect(eva!.conversationId).toBe(evalConversationId("test"));
-    expect(gen!.conversationId).not.toBe(eva!.conversationId);
     expect(gen!.mode).toBe("normal");
     expect(gen!.idempotencyKey).toContain("loop-gen:test:item-1:");
+    // the seeded workflow instruction rides the prompt
+    expect(gen!.message?.text).toContain(".workflows/loop.js");
   });
 
-  test("PASS verdict → item resolved; generatorRunId + evaluatorRunId persisted", async () => {
+  test("PASS verdict via workflow meta → awaiting_review; generatorRunId persisted", async () => {
     const store = createTestStore();
     stateWithFixingItem(store);
-    const { enqueues } = await runStep({
+    await runStep({
       store,
-      script: { evalVerdictMd: "verdict: PASS\nevidence: tests green" },
+      script: {
+        workflowMeta: {
+          "item-1": {
+            id: "item-1",
+            step: "verifying",
+            result: { verdict: "PASS", evidence: "tests green" },
+          },
+        },
+      },
     });
-    const gen = enqueues.find((e) => e.agentMemberId.startsWith("loop-generator"))!;
-    const eva = enqueues.find((e) => e.agentMemberId.startsWith("loop-evaluator"))!;
 
     const saved = store.load("test");
     const item = Object.values(saved.items)[0]!;
     expect(item.step).toBe("awaiting_review");
-    // generatorRunId field now carries the Agent Run id
+    // generatorRunId field now carries the Agent Run id; no evaluator run id
     expect(item.generatorRunId).toMatch(/^run-\d+$/);
-    expect(item.evaluatorRunId).toMatch(/^run-\d+$/);
-    expect(item.evaluatorRunId).not.toBe(item.generatorRunId);
+    expect(item.evaluatorRunId).toBeFalsy();
     expect(item.result?.verdict).toBe("PASS");
-    void gen;
-    void eva;
   });
 
   test("generator run queued → loopStep fails (no dispatch of a second run)", async () => {
@@ -432,10 +434,7 @@ describe("loopStep — Generator/Evaluator as Agent Runs", () => {
     stateWithFixingItem(store);
     const { enqueues } = await runStep({
       store,
-      script: {
-        genReplayTerminal: true,
-        evalVerdictMd: "verdict: PASS\nevidence: e",
-      },
+      script: { genReplayTerminal: true },
     });
     // first enqueue replayed the terminal run; the retry-scoped key acquired
     // a fresh run and the loop completed normally
@@ -468,7 +467,15 @@ describe("loopStep — Generator/Evaluator as Agent Runs", () => {
     const { result } = await runStep({
       store,
       gitRunner,
-      script: { evalVerdictMd: "verdict: REJECT\nreason: not good\nevidence: e" },
+      script: {
+        workflowMeta: {
+          "item-1": {
+            id: "item-1",
+            step: "verifying",
+            result: { verdict: "REJECT", reasons: ["not good"], evidence: "e" },
+          },
+        },
+      },
     });
     const item = result.items["item-1"]!;
     expect(item.step).toBe("fixing");
@@ -489,26 +496,13 @@ describe("loopStep — Generator/Evaluator as Agent Runs", () => {
     expect(result.items["item-1"]!.result?.verdict).toBe("REJECT");
   });
 
-  test("empty VERDICT.md → ESCALATE to inbox", async () => {
+  test("no workflow meta writeback → ESCALATE to inbox", async () => {
     const store = createTestStore();
     stateWithFixingItem(store);
-    const { result } = await runStep({ store, script: { evalVerdictMd: "" } });
+    const { result } = await runStep({ store, script: { workflowMeta: null } });
     const item = result.items["item-1"]!;
     expect(item.step).toBe("inbox");
     expect(item.result?.verdict).toBe("ESCALATE");
-  });
-
-  test("evaluator timeout (aborted) → no crash, ESCALATE on empty verdict", async () => {
-    const store = createTestStore();
-    stateWithFixingItem(store);
-    const { result } = await runStep({
-      store,
-      script: { evalStatus: "aborted", evalVerdictMd: "" },
-    });
-    const item = result.items["item-1"]!;
-    expect(item.step).toBe("inbox");
-    expect(item.result?.verdict).toBe("ESCALATE");
-    expect(item.evaluatorRunId).toBeTruthy();
   });
 
   test("human APPROVE → resolved item removed from store", async () => {
@@ -542,13 +536,9 @@ describe("loopStep — Generator/Evaluator as Agent Runs", () => {
     const store = createTestStore();
     stateWithFixingItem(store);
     const dir = await initLoopDir("test-project", undefined, "  dailyCap: 10000");
-    await runStep({
-      store,
-      dir,
-      script: { evalVerdictMd: "verdict: PASS\nevidence: e", usageTokens: 1500 },
-    });
+    await runStep({ store, dir, script: { usageTokens: 1500 } });
     const spent = store.getBudget("test", new Date().toISOString().slice(0, 10));
-    expect(spent).toBe(3000); // gen + eval
+    expect(spent).toBe(1500); // one generator run (the evaluator Run is gone)
   });
 
   test("generator prompt includes repo path + git log context", async () => {
@@ -568,7 +558,7 @@ describe("loopStep — Generator/Evaluator as Agent Runs", () => {
         dataDir,
         projectPort,
         gitRunner,
-        script: { evalVerdictMd: "verdict: PASS\nevidence: e" },
+        script: {},
       });
       const gen = enqueues.find((e) => e.agentMemberId.startsWith("loop-generator"))!;
       expect(gen.message.text).toContain(`${dataDir}/repos/test-project`);

--- a/apps/backend/src/features/loop/loop-step.test.ts
+++ b/apps/backend/src/features/loop/loop-step.test.ts
@@ -167,6 +167,7 @@ function makeFakeRuns(script: RunScript, workDir: string = "") {
       permissionMode: null,
       todoSnapshot: null,
       workspace: null,
+      workflowBudgetTokens: null,
       createdAt: 0,
       terminalAt: null,
     };

--- a/apps/backend/src/features/loop/loop-step.ts
+++ b/apps/backend/src/features/loop/loop-step.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import type { BackendModelRef, BackendRunOutcome } from "@my-agent-team/agent-backend";
-import type { LoopConfig, LoopState } from "@my-agent-team/loop";
-import { loopReducer, parseLoopConfig, parseVerdictMd } from "@my-agent-team/loop";
+import type { LoopConfig, LoopState, Verdict } from "@my-agent-team/loop";
+import { loopReducer, parseLoopConfig, validateLoopMetaPatch } from "@my-agent-team/loop";
 import { isTerminalStatus } from "../agent-run/domain.js";
 import type { AgentRunExecutionService } from "../agent-run/execution.js";
 import type { AgentRunService } from "../agent-run/service.js";
@@ -42,6 +42,9 @@ export interface LoopStepParams {
   agentRunExecution: AgentRunExecutionService;
   /** Resolve a LOOP.md model name to a BackendModelRef. */
   resolveModel: (modelName: string) => Promise<BackendModelRef>;
+  /** The repo builtin skills dir (workflow authoring etc.); prepended to
+   *  the generator's skill roots when provided. */
+  builtinSkillsDir?: string;
 }
 
 /** Stable deterministic identities - Generator and Evaluator are fully
@@ -49,14 +52,8 @@ export interface LoopStepParams {
 export function loopGeneratorConversationId(loopId: string): string {
   return `loop:${loopId}:generator`;
 }
-export function loopEvaluatorConversationId(loopId: string): string {
-  return `loop:${loopId}:evaluator`;
-}
 export function loopGeneratorMemberId(loopId: string): string {
   return `loop-generator:${loopId}`;
-}
-export function loopEvaluatorMemberId(loopId: string): string {
-  return `loop-evaluator:${loopId}`;
 }
 
 function usageTokens(usage: BackendRunOutcome["usage"] | null | undefined): number {
@@ -166,6 +163,59 @@ function actionToReducer(action: ReviewAction) {
   }
 }
 
+/** The workflow script the Loop seeds per item. The meta block carries
+ *  the item's state (seeded as JSON); the model updates it after the run
+ *  via the write tool, and the product validates the writeback with
+ *  validateLoopMetaPatch before applying the verdict. */
+const LOOP_WORKFLOW_TEMPLATE = `// Loop workflow (product-seeded). Update the meta block after the run
+// with the item's new step (a legal transition) and its verdict result.
+export const meta = __META_JSON__;
+
+const item = Object.values(meta.items)[0];
+const fix = await agent(
+  \`Fix the loop item. Summary: \${item.summary}. Source: \${item.source}. Smallest possible diff; do not commit.\`,
+  { label: \`\${item.id}-fix\` },
+);
+const verdict = await agent(
+  \`Verify the fix for item \${item.id}. Run the relevant tests and return JSON: {"verdict":"PASS"|"REJECT"|"ESCALATE","reasons":[],"evidence":"..."}.\`,
+  {
+    label: \`\${item.id}-verify\`,
+    schema: {
+      type: "object",
+      properties: {
+        verdict: { type: "string", enum: ["PASS", "REJECT", "ESCALATE"] },
+        reasons: { type: "array" },
+        evidence: { type: "string" },
+      },
+      required: ["verdict", "evidence"],
+    },
+  },
+);
+// After this workflow, use the write tool to update the meta block above:
+// the item's step (legal edge) and result (the verdict JSON above).
+return { id: item.id, verdict: verdict.output, fixText: fix.text };
+`;
+
+function seedLoopWorkflowScript(item: LoopState["items"][string]): string {
+  const metaJson = JSON.stringify({ items: { [item.id]: item } });
+  return LOOP_WORKFLOW_TEMPLATE.replace("__META_JSON__", metaJson);
+}
+
+/** Extract the model-edited meta block: balanced-brace scan + lenient JSON
+ *  (line comments + trailing commas stripped). Null = unparseable. */
+function extractLoopWorkflowMeta(script: string): LoopState | null {
+  const m = script.match(/export const meta\s*=\s*(\{[\s\S]*?\});/);
+  if (!m || !m[1]) return null;
+  const cleaned = m[1].replace(/\/\/[^\n]*/g, "").replace(/,\s*([}\]])/g, "$1");
+  try {
+    const parsed = JSON.parse(cleaned) as { items?: LoopState["items"] };
+    if (!parsed.items || typeof parsed.items !== "object") return null;
+    return { loopId: "", lastRun: null, items: parsed.items };
+  } catch {
+    return null;
+  }
+}
+
 function buildGeneratorPrompt(
   item: LoopState["items"][string],
   template: string,
@@ -197,7 +247,6 @@ export async function loopStep(params: LoopStepParams): Promise<LoopState> {
 
 async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
   const repoPath = await resolveRepoPath(params.loopConfigPath, params.projectPort, params.dataDir);
-  const workDir = repoPath ?? params.loopConfigPath;
 
   // 1. Read state from DB
   let state = params.store.load(params.loopId);
@@ -228,10 +277,7 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
   }
 
   const genModel = cfg.generator.model;
-  const evalModel = cfg.evaluator.model;
   const genPrompt = cfg.generator.systemPrompt;
-  const evalPrompt = cfg.evaluator.systemPrompt;
-  const acceptance = cfg.acceptance || "被修改的文件相关测试全绿，改动范围合理";
   const denylist: string[] = cfg.denylist;
   const dailyCap = cfg.budget?.dailyCap ?? 0;
 
@@ -335,7 +381,10 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
 
     const baseSha = (await git.revParse(cwd)).text().trim();
 
-    // ── Generator: one Agent Run on its own stable scope ──
+    // ── Generator: one Agent Run per item, workflow-driven ──
+    // The Loop seeds the workflow script (meta = this item's state); the
+    // generator runs it (fix fan-out + self-verification) and writes the
+    // verdict back into the script's meta via the write tool.
     const genConversationId = loopGeneratorConversationId(params.loopId);
     const genMemberId = loopGeneratorMemberId(params.loopId);
     await ensureLoopScope(params.convPort, genConversationId, genMemberId, "default");
@@ -344,6 +393,17 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
       .quiet()
       .text()
       .catch(() => "");
+    await Bun.write(`${cwd}/.workflows/loop.js`, seedLoopWorkflowScript(item)).catch(() => {});
+    const genPromptFull = [
+      buildGeneratorPrompt(item, genPrompt, { repoPath: cwd, gitLog }),
+      `# Workflow\nThe script at .workflows/loop.js carries this item's state in its meta block. ` +
+        `Run it with the workflow_run tool (pass the script text). After the workflow completes, ` +
+        `use the write tool to update the meta block in .workflows/loop.js: the item's step must ` +
+        `follow a legal transition and its result must be the verdict JSON from the verify agent.`,
+    ].join("\n\n");
+    const genSkillRoots = params.builtinSkillsDir
+      ? [params.builtinSkillsDir, `${params.loopConfigPath}/skills`]
+      : [`${params.loopConfigPath}/skills`];
     let genAcquire = await params.agentRunService.enqueueAndAcquire({
       conversationId: genConversationId,
       agentMemberId: genMemberId,
@@ -351,18 +411,21 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
       mode: "normal",
       message: {
         role: "user",
-        text: buildGeneratorPrompt(item, genPrompt, { repoPath: cwd, gitLog }),
+        text: genPromptFull,
       },
       defaultModel: await params.resolveModel(genModel),
       configRevision: 1,
       idempotencyKey: `loop-gen:${params.loopId}:${item.id}:${baseSha}`,
       // LOOP.md generator systemPrompt is the frozen Run system prompt;
-      // skills live in the loop config's skills/ dir.
+      // skills live in the loop config's skills/ dir + the builtin docs.
       systemPrompt: genPrompt || undefined,
-      skillRoots: [`${params.loopConfigPath}/skills`],
+      skillRoots: genSkillRoots,
       // Workspace is a Run execution fact: the Generator MUST run in the
       // cloned repo, not the loop-agent's own workspace.
       workspace: { root: cwd, access: "read_write" },
+      // Freeze the remaining daily budget on the Run: the child's workflow
+      // executor gates subagent spawns against it.
+      ...(dailyCap > 0 ? { workflowBudgetTokens: Math.max(0, dailyCap - spent) } : {}),
     });
     if (
       genAcquire.replayed &&
@@ -380,14 +443,15 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
         mode: "normal",
         message: {
           role: "user",
-          text: buildGeneratorPrompt(item, genPrompt, { repoPath: cwd, gitLog }),
+          text: genPromptFull,
         },
         defaultModel: await params.resolveModel(genModel),
         configRevision: 1,
         idempotencyKey: `loop-gen:${params.loopId}:${item.id}:${baseSha}:retry`,
         systemPrompt: genPrompt || undefined,
-        skillRoots: [`${params.loopConfigPath}/skills`],
+        skillRoots: genSkillRoots,
         workspace: { root: cwd, access: "read_write" },
+        ...(dailyCap > 0 ? { workflowBudgetTokens: Math.max(0, dailyCap - spent) } : {}),
       });
       if (retry.acquired && retry.run) {
         genAcquire = { ...retry, replayed: false };
@@ -431,116 +495,47 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
         verdict: {
           verdict: "REJECT",
           reasons: [`修改了 denylist 保护路径: ${violations.join(", ")}`],
-          evidence: "denylist check (pre-evaluator)",
+          evidence: "denylist check (pre-verifier)",
         },
       });
       await git.resetHard(cwd, baseSha);
       continue;
     }
 
-    // ── Evaluator: separate stable scope, only after deterministic prep ──
-    // The user prompt ALWAYS carries acceptance criteria, the changed files
-    // and the VERDICT.md requirement; the LOOP.md systemPrompt is only an
-    // extra behavioral constraint (frozen into the Run as systemPrompt).
-    const evaluatorPrompt = [
-      `# Acceptance Criteria\n${acceptance}`,
-      `# Files Changed\n${filesChanged || "none"}`,
-      `# Task\nReview the changes in the workspace against the acceptance criteria. ` +
-        `Write your verdict to VERDICT.md in the workspace root. The file must contain YAML with: ` +
-        `verdict: PASS | REJECT | ESCALATE, reasons: [...], evidence: "..."`,
-      ...(evalPrompt.trim() ? [`# Additional Instructions\n${evalPrompt.trim()}`] : []),
-    ].join("\n\n");
-    const evalConversationId = loopEvaluatorConversationId(params.loopId);
-    const evalMemberId = loopEvaluatorMemberId(params.loopId);
-    await ensureLoopScope(params.convPort, evalConversationId, evalMemberId, "default");
-
-    const verdictPath = `${workDir}/VERDICT.md`;
-    try {
-      await Bun.write(verdictPath, "");
-    } catch {
-      // ignore
-    }
-
-    let evalAcquire = await params.agentRunService.enqueueAndAcquire({
-      conversationId: evalConversationId,
-      agentMemberId: evalMemberId,
-      backendKind: "coding_agent",
-      mode: "normal",
-      message: { role: "user", text: evaluatorPrompt },
-      defaultModel: await params.resolveModel(evalModel),
-      configRevision: 1,
-      idempotencyKey: `loop-eval:${params.loopId}:${item.id}:${baseSha}`,
-      // Evaluator systemPrompt from LOOP.md; skills from the loop config.
-      systemPrompt: evalPrompt || undefined,
-      skillRoots: [`${params.loopConfigPath}/skills`],
-      // The Evaluator writes VERDICT.md into the same clone; read_write is
-      // honest until the verdict moves out-of-band.
-      workspace: { root: workDir, access: "read_write" },
-    });
-    if (
-      evalAcquire.replayed &&
-      evalAcquire.run &&
-      isTerminalStatus(evalAcquire.run.status) &&
-      evalAcquire.run.status !== "completed"
-    ) {
-      const retry = await params.agentRunService.enqueueAndAcquire({
-        conversationId: evalConversationId,
-        agentMemberId: evalMemberId,
-        backendKind: "coding_agent",
-        mode: "normal",
-        message: { role: "user", text: evaluatorPrompt },
-        defaultModel: await params.resolveModel(evalModel),
-        configRevision: 1,
-        idempotencyKey: `loop-eval:${params.loopId}:${item.id}:${baseSha}:retry`,
-        systemPrompt: evalPrompt || undefined,
-        skillRoots: [`${params.loopConfigPath}/skills`],
-        workspace: { root: workDir, access: "read_write" },
-      });
-      if (retry.acquired && retry.run) {
-        evalAcquire = { ...retry, replayed: false };
-      }
-    }
-    if (!evalAcquire.acquired || !evalAcquire.run) {
-      throw new Error(
-        `loopStep: evaluator run for item ${item.id} could not acquire its branch (queued behind an active run)`,
-      );
-    }
-    const evaluatorRunId = evalAcquire.run.runId;
-    const EVALUATOR_TIMEOUT_MS = 60_000;
-    const evalWatchdog = setTimeout(() => {
-      void params.agentRunExecution.stop(evaluatorRunId).catch(() => {});
-    }, EVALUATOR_TIMEOUT_MS);
-    try {
-      await params.agentRunExecution.dispatch(evaluatorRunId);
-    } finally {
-      clearTimeout(evalWatchdog);
-    }
-    const evalRun = await params.agentRunService.getRun(evaluatorRunId);
-    if (dailyCap > 0) {
-      spent = params.store.addBudget(
-        params.loopId,
-        today,
-        usageTokens(evalRun?.terminalResult?.usage),
-      );
-    }
-    // Read verdict (the file content is the verdict fact; the run outcome
-    // only says whether execution completed)
-    const verdictMd = await Bun.file(verdictPath)
+    // ── Workflow verdict: the script's meta carries the result ──
+    // The model wrote the verdict into .workflows/loop.js; the product
+    // validates the writeback against the pure reducer invariants and
+    // applies the EVALUATOR_VERDICT transition. No separate evaluator Run.
+    const scriptText = await Bun.file(`${cwd}/.workflows/loop.js`)
       .text()
       .catch(() => "");
-    let verdict = parseVerdictMd(verdictMd);
-    if (!verdictMd.trim()) {
-      verdict = { verdict: "ESCALATE", reasons: ["evaluator produced no verdict"], evidence: "" };
+    const writtenMeta = extractLoopWorkflowMeta(scriptText);
+    const seedMeta: LoopState = {
+      loopId: params.loopId,
+      lastRun: null,
+      items: { [item.id]: item },
+    };
+    const noVerdict = (reason: string): Verdict => ({
+      verdict: "ESCALATE",
+      reasons: [reason],
+      evidence: "",
+    });
+    let verdict: Verdict;
+    if (!writtenMeta) {
+      verdict = noVerdict("workflow script has no parseable meta block");
+    } else {
+      const validation = validateLoopMetaPatch(seedMeta, writtenMeta);
+      if (!validation.ok) {
+        verdict = noVerdict(`workflow meta writeback invalid: ${validation.reason}`);
+      } else {
+        verdict = writtenMeta.items[item.id]?.result ?? noVerdict("workflow wrote no verdict");
+      }
     }
-
-    if (verdict) {
-      state = loopReducer(state, {
-        type: "EVALUATOR_VERDICT",
-        itemId: item.id,
-        verdict,
-        evaluatorRunId,
-      });
-    }
+    state = loopReducer(state, {
+      type: "EVALUATOR_VERDICT",
+      itemId: item.id,
+      verdict,
+    });
 
     // Rollback on REJECT/ESCALATE
     const updatedItem = state.items[item.id];

--- a/apps/backend/src/features/loop/loop-step.ts
+++ b/apps/backend/src/features/loop/loop-step.ts
@@ -205,7 +205,7 @@ function seedLoopWorkflowScript(item: LoopState["items"][string]): string {
  *  (line comments + trailing commas stripped). Null = unparseable. */
 function extractLoopWorkflowMeta(script: string): LoopState | null {
   const m = script.match(/export const meta\s*=\s*(\{[\s\S]*?\});/);
-  if (!m || !m[1]) return null;
+  if (!m?.[1]) return null;
   const cleaned = m[1].replace(/\/\/[^\n]*/g, "").replace(/,\s*([}\]])/g, "$1");
   try {
     const parsed = JSON.parse(cleaned) as { items?: LoopState["items"] };

--- a/apps/backend/src/infra/db/schema.ts
+++ b/apps/backend/src/infra/db/schema.ts
@@ -369,12 +369,18 @@ export const agentRun = sqliteTable(
     systemPrompt: text("system_prompt"),
     /** JSON: frozen skill pack roots (absolute dirs scanned for SKILL.md). */
     skillRoots: text("skill_roots"),
+<<<<<<< HEAD
     /** Frozen permission_mode (ask/auto/deny), mapped per backend at
      *  dispatch (ADR 0020 decision 7; claude --permission-mode). */
     permissionMode: text("permission_mode"),
     /** JSON: the run's latest task list snapshot (todo_write product tool).
      *  Re-injected into the next run's prompt as the Current Tasks section. */
     todoSnapshot: text("todo_snapshot"),
+=======
+    /** Optional workflow budget (tokens): the Loop freezes the remaining
+     *  daily budget at dispatch; the child gates subagent spawns on it. */
+    workflowBudgetTokens: integer("workflow_budget_tokens"),
+>>>>>>> 8d65e63f (feat(agent-run): workflow budget frozen on runs and gated in the child)
     createdAt: integer("created_at", { mode: "number" }).notNull(),
     terminalAt: integer("terminal_at", { mode: "number" }),
   },
@@ -415,7 +421,13 @@ export const branchInputQueue = sqliteTable(
     workspaceAccess: text("workspace_access"),
     systemPrompt: text("system_prompt"),
     skillRoots: text("skill_roots"), // JSON: readonly string[]
+<<<<<<< HEAD
     permissionMode: text("permission_mode"),
+=======
+    /** Optional workflow budget (tokens), frozen at enqueue; the child
+     *  gates workflow subagent spawns on it. */
+    workflowBudgetTokens: integer("workflow_budget_tokens"),
+>>>>>>> 8d65e63f (feat(agent-run): workflow budget frozen on runs and gated in the child)
     createdAt: integer("created_at", { mode: "number" }).notNull(),
     deliveredAt: integer("delivered_at", { mode: "number" }),
   },

--- a/apps/backend/src/infra/db/schema.ts
+++ b/apps/backend/src/infra/db/schema.ts
@@ -369,18 +369,15 @@ export const agentRun = sqliteTable(
     systemPrompt: text("system_prompt"),
     /** JSON: frozen skill pack roots (absolute dirs scanned for SKILL.md). */
     skillRoots: text("skill_roots"),
-<<<<<<< HEAD
     /** Frozen permission_mode (ask/auto/deny), mapped per backend at
      *  dispatch (ADR 0020 decision 7; claude --permission-mode). */
     permissionMode: text("permission_mode"),
     /** JSON: the run's latest task list snapshot (todo_write product tool).
      *  Re-injected into the next run's prompt as the Current Tasks section. */
     todoSnapshot: text("todo_snapshot"),
-=======
     /** Optional workflow budget (tokens): the Loop freezes the remaining
      *  daily budget at dispatch; the child gates subagent spawns on it. */
     workflowBudgetTokens: integer("workflow_budget_tokens"),
->>>>>>> 8d65e63f (feat(agent-run): workflow budget frozen on runs and gated in the child)
     createdAt: integer("created_at", { mode: "number" }).notNull(),
     terminalAt: integer("terminal_at", { mode: "number" }),
   },
@@ -421,13 +418,10 @@ export const branchInputQueue = sqliteTable(
     workspaceAccess: text("workspace_access"),
     systemPrompt: text("system_prompt"),
     skillRoots: text("skill_roots"), // JSON: readonly string[]
-<<<<<<< HEAD
     permissionMode: text("permission_mode"),
-=======
     /** Optional workflow budget (tokens), frozen at enqueue; the child
      *  gates workflow subagent spawns on it. */
     workflowBudgetTokens: integer("workflow_budget_tokens"),
->>>>>>> 8d65e63f (feat(agent-run): workflow budget frozen on runs and gated in the child)
     createdAt: integer("created_at", { mode: "number" }).notNull(),
     deliveredAt: integer("delivered_at", { mode: "number" }),
   },

--- a/apps/backend/tests/integration/loop-coding-agent.test.ts
+++ b/apps/backend/tests/integration/loop-coding-agent.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@my-agent-team/adapter-coding-agent";
 import type { BackendEvent } from "@my-agent-team/agent-backend";
 import type { LoopState } from "@my-agent-team/loop";
-import { loopReducer, parseVerdictMd } from "@my-agent-team/loop";
+import { loopReducer } from "@my-agent-team/loop";
 import {
   createAgentContextService,
   sqliteAgentContextAdapter,
@@ -28,7 +28,7 @@ import { openDb } from "../../src/infra/sqlite/db.js";
 
 /** THE real Loop chain: loopStep → AgentRunService → AgentRunExecution →
  *  real coding-agent child (--mode rpc, fake provider) → git mutations in
- *  the cloned repo → git diff base..head → evaluator writes VERDICT.md →
+ *  the cloned repo → the workflow meta writeback (reducer-validated) →
  *  reducer transition. Skills come from <loopConfigPath>/skills and are
  *  loaded by the real child (skill_load tool result observed in events).
  *
@@ -57,18 +57,35 @@ const eventLog = new Map<string, BackendEvent<"coding_agent">[]>();
 /** The scripted tool script: ONE branch for both roles, decided by the
  *  workspace state:
  *  - generator (changes.txt missing): commit a change to the clone;
- *  - evaluator (changes.txt present): write VERDICT.md.
+ *  - verifier (changes.txt present): write the workflow meta verdict.
  *  The second entry proves the real child loaded <loopConfigPath>/skills:
  *  skill_load must resolve the loop-skill body (visible in events). */
+const LOOP_META_JSON = JSON.stringify({
+  items: {
+    [ITEM_ID]: {
+      id: ITEM_ID,
+      step: "verifying",
+      result: { verdict: "PASS", evidence: "loop-e2e" },
+    },
+  },
+});
 const FAKE_TOOL_SCRIPT = JSON.stringify([
   {
     name: "bash",
     input: {
       command:
-        "if [ -f changes.txt ]; then printf 'verdict: PASS\\nevidence: \"loop-e2e\"\\n' > VERDICT.md; else echo phase5 >> changes.txt && git add -A && git -c user.name=loop -c user.email=loop@test commit -m phase5-change; fi",
+        "echo phase5 >> changes.txt && git add -A && git -c user.name=loop -c user.email=loop@test commit -m phase5-change",
     },
   },
   { name: "skill_load", input: { name: "loop-skill" } },
+  {
+    name: "bash",
+    input: {
+      command: `cat > .workflows/loop.js <<'WFE'
+export const meta = ${LOOP_META_JSON};
+WFE`,
+    },
+  },
 ]);
 
 async function setupRemoteRepo(): Promise<string> {
@@ -206,7 +223,7 @@ afterAll(async () => {
 });
 
 describe("Loop with a REAL coding-agent child", () => {
-  test("generator commits to the clone, loads loop skills, evaluator writes VERDICT.md", async () => {
+  test("generator commits to the clone, loads loop skills, writes the workflow meta", async () => {
     const projectPort = {
       createProject: () => {
         throw new Error("not implemented");
@@ -245,8 +262,9 @@ describe("Loop with a REAL coding-agent child", () => {
 
     // ── State machine: generator + evaluator ran, verdict PASS ──
     const item = result.items[ITEM_ID]!;
+
     expect(item.generatorRunId).toBeTruthy();
-    expect(item.evaluatorRunId).toBeTruthy();
+    expect(item.evaluatorRunId).toBeFalsy();
     expect(item.result?.verdict).toBe("PASS");
 
     // ── The generator REALLY modified and committed the clone ──
@@ -256,10 +274,9 @@ describe("Loop with a REAL coding-agent child", () => {
     const diff = await Bun.$`git -C ${clone} diff HEAD~1..HEAD --name-only`.quiet().text();
     expect(diff).toContain("changes.txt");
 
-    // ── The evaluator REALLY wrote VERDICT.md in the clone ──
-    const verdictMd = await Bun.file(join(clone, "VERDICT.md")).text();
-    const verdict = parseVerdictMd(verdictMd);
-    expect(verdict?.verdict).toBe("PASS");
+    // ── The workflow meta really landed in the clone ──
+    const metaScript = await Bun.file(join(clone, ".workflows", "loop.js")).text();
+    expect(metaScript).toContain('"verdict":"PASS"');
 
     // ── The real child loaded <loopConfigPath>/skills: skill_load
     //    resolved the loop-skill body (observable in the run events) ──

--- a/apps/coding-agent/src/core/__fixtures__/echo-model.ts
+++ b/apps/coding-agent/src/core/__fixtures__/echo-model.ts
@@ -1,0 +1,12 @@
+import type { AIMessageChunk } from "@my-agent-team/core";
+
+/** Deterministic scripted model stream: yields one assistant text chunk, a
+ *  usage record, and end_turn - the minimal shape the agent loop needs to
+ *  complete a turn. */
+export function createEchoModelStream(text: string): () => AsyncIterable<AIMessageChunk> {
+  return async function* () {
+    yield { delta: { type: "text", text } } as AIMessageChunk;
+    yield { usage: { input: 10, output: 3, cacheRead: 1, cacheCreate: 0 } } as AIMessageChunk;
+    yield { stopReason: "end_turn" } as AIMessageChunk;
+  };
+}

--- a/apps/coding-agent/src/core/create-runtime.test.ts
+++ b/apps/coding-agent/src/core/create-runtime.test.ts
@@ -360,4 +360,64 @@ describe("createCodingAgentRuntime", () => {
     expect(batches[0]!.model.id).toBe("big");
     await rt.close();
   });
+  test("run_workflow fans out subagents and reports workflow events (phase 1)", async () => {
+    const requests: string[] = [];
+    const provider: Provider = {
+      id: "fake",
+      name: "Fake",
+      getModels: () => [FAKE_MODEL],
+      async *stream(_model: Model, messages: readonly Message[]): AsyncIterable<AIMessageChunk> {
+        const system = messages.find((m) => m.role === "system");
+        if (system?.text.includes("You are a subagent")) {
+          requests.push("subagent");
+          yield { delta: { type: "text", text: "sub-result" } };
+          yield { usage: { input: 10, output: 3, cacheRead: 1, cacheCreate: 0 } };
+          yield { stopReason: "end_turn" };
+          return;
+        }
+        if (!requests.includes("tool")) {
+          requests.push("tool");
+          yield { delta: { type: "tool_use", id: "toolu-1", name: "run_workflow" } };
+          yield {
+            delta: {
+              type: "input_json_delta",
+              id: "toolu-1",
+              partial_json: JSON.stringify({
+                items: [
+                  { prompt: "one", label: "a" },
+                  { prompt: "two", label: "b" },
+                ],
+              }),
+            },
+          };
+          yield { stopReason: "tool_use" };
+          return;
+        }
+        requests.push("main");
+        yield { delta: { type: "text", text: "done" } };
+        yield { usage: { input: 10, output: 3, cacheRead: 1, cacheCreate: 0 } };
+        yield { stopReason: "end_turn" };
+      },
+    };
+    const modelRuntime = createModelRuntime();
+    modelRuntime.registerProvider(provider);
+    const runtime = await createCodingAgentRuntime({
+      runId: "r-wf",
+      modelId: "fake/echo",
+      workspaceRoot: tmp,
+      workspaceAccess: "read_write",
+      modelRuntime,
+      skillRoots: [],
+    });
+    const segment = await runtime.run(runInput("r-wf"));
+    const { outcome, events } = await settle(segment);
+    await runtime.close();
+    expect(outcome.status).toBe("completed");
+    // Two subagent streams + one main tool turn + one final main turn.
+    expect(requests.filter((r) => r === "subagent")).toHaveLength(2);
+    expect(events).toContain("workflow_started");
+    expect(events).toContain("workflow_agent_started");
+    expect(events).toContain("workflow_agent_completed");
+    expect(events).toContain("workflow_completed");
+  });
 });

--- a/apps/coding-agent/src/core/create-runtime.test.ts
+++ b/apps/coding-agent/src/core/create-runtime.test.ts
@@ -420,4 +420,61 @@ describe("createCodingAgentRuntime", () => {
     expect(events).toContain("workflow_agent_completed");
     expect(events).toContain("workflow_completed");
   });
+  test("workflow_run evaluates a script, fans out agents, and persists .workflows", async () => {
+    const requests: string[] = [];
+    const script =
+      'const a = await agent("one"); const b = await agent("two"); return [a.text, b.text];';
+    const provider: Provider = {
+      id: "fake",
+      name: "Fake",
+      getModels: () => [FAKE_MODEL],
+      async *stream(_model: Model, messages: readonly Message[]): AsyncIterable<AIMessageChunk> {
+        const system = messages.find((m) => m.role === "system");
+        if (system?.text.includes("You are a subagent")) {
+          requests.push("subagent");
+          yield { delta: { type: "text", text: "sub-result" } };
+          yield { usage: { input: 10, output: 3, cacheRead: 1, cacheCreate: 0 } };
+          yield { stopReason: "end_turn" };
+          return;
+        }
+        if (!requests.includes("script")) {
+          requests.push("script");
+          yield { delta: { type: "tool_use", id: "toolu-2", name: "workflow_run" } };
+          yield {
+            delta: {
+              type: "input_json_delta",
+              id: "toolu-2",
+              partial_json: JSON.stringify({ script, name: "audit" }),
+            },
+          };
+          yield { stopReason: "tool_use" };
+          return;
+        }
+        requests.push("main");
+        yield { delta: { type: "text", text: "done" } };
+        yield { usage: { input: 10, output: 3, cacheRead: 1, cacheCreate: 0 } };
+        yield { stopReason: "end_turn" };
+      },
+    };
+    const modelRuntime = createModelRuntime();
+    modelRuntime.registerProvider(provider);
+    const runtime = await createCodingAgentRuntime({
+      runId: "r-wfs",
+      modelId: "fake/echo",
+      workspaceRoot: tmp,
+      workspaceAccess: "read_write",
+      modelRuntime,
+      skillRoots: [],
+    });
+    const segment = await runtime.run(runInput("r-wfs"));
+    const { outcome, events } = await settle(segment);
+    await runtime.close();
+    expect(outcome.status).toBe("completed");
+    expect(requests.filter((r) => r === "subagent")).toHaveLength(2);
+    expect(events).toContain("workflow_agent_completed");
+    expect(events).toContain("workflow_completed");
+    // The script persists to the workspace for inspection/re-runs.
+    const saved = await Bun.file(join(tmp, ".workflows", "audit.js")).text();
+    expect(saved).toBe(script);
+  });
 });

--- a/apps/coding-agent/src/core/run-runtime.ts
+++ b/apps/coding-agent/src/core/run-runtime.ts
@@ -37,6 +37,7 @@ import {
   type WebSearchPort,
 } from "@my-agent-team/tools-common";
 import { fakeProvider } from "./fake-provider.js";
+import { mountWorkspaceMcpServers } from "./mcp-mount.js";
 
 import type { ProductToolCaller } from "./product-tool-transport.js";
 import { readProductToolsManifest } from "./product-tools-manifest.js";
@@ -144,8 +145,8 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
   // Generic .mcp.json mounting (ADR 0022): user servers + knowledge.
   // Skips "product-tools" (the manifest path owns it) and names that
   // collide with the native table.
-  tools.push(
-    ...(await mountWorkspaceMcpServers(deps.workspaceRoot, new Set(tools.map((t) => t.name)))),
+  fileTools.push(
+    ...(await mountWorkspaceMcpServers(deps.workspaceRoot, new Set(fileTools.map((t) => t.name)))),
   );
   if (deps.webSearch) {
     fileTools.push(createPortWebSearchTool(deps.webSearch) as unknown as PluginTool);

--- a/apps/coding-agent/src/core/run-runtime.ts
+++ b/apps/coding-agent/src/core/run-runtime.ts
@@ -365,6 +365,31 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
   // Two-phase: sessionEmit is bound after session creation (the session's
   // emit method doesn't exist until createCodingAgentSession returns).
   let sessionEmit: ((event: CodingAgentLoopEvent) => void) | null = null;
+  // The workflow executor rides the SAME model stream + summarizer as the
+  // main loop; subagents get the file tools only (no workflow/product tools).
+  // Registered BEFORE createCodingAgentSession: the session snapshots the
+  // plugin tool table at construction time.
+  const workflowExecutor = createWorkflowExecutor({
+    makeSubagentStream: () => streamModel,
+    modelId: deps.modelId,
+    summarize,
+    contextBudget,
+    tools: fileTools,
+    workspaceRoot: deps.workspaceRoot,
+    workspaceAccess: deps.workspaceAccess,
+    maxConcurrent: 8,
+    maxTotal: 64,
+    emit: (event) => sessionEmit?.(event as never),
+  });
+  plugins.push({
+    name: "workflow-tools",
+    tools: createWorkflowTools({
+      runWorkflow: (input) => workflowExecutor.runWorkflow(input),
+      runScript: async () => {
+        throw new Error("workflow_run arrives in phase 2");
+      },
+    }),
+  });
   const pluginRuntime: PluginRuntime = {
     streamModel: (providerId, modelId, messages, opts) =>
       deps.modelRuntime.stream(providerId, modelId, messages, opts),
@@ -443,29 +468,6 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
 
   // Bind the plugin runtime's emit to the session's emit (two-phase init).
   sessionEmit = (event) => session.emit(event);
-  // The workflow executor rides the SAME model stream + summarizer as the
-  // main loop; subagents get the file tools only (no workflow/product tools).
-  const workflowExecutor = createWorkflowExecutor({
-    makeSubagentStream: () => streamModel,
-    modelId: deps.modelId,
-    summarize,
-    contextBudget,
-    tools: fileTools,
-    workspaceRoot: deps.workspaceRoot,
-    workspaceAccess: deps.workspaceAccess,
-    maxConcurrent: 8,
-    maxTotal: 64,
-    emit: (event) => sessionEmit?.(event as never),
-  });
-  plugins.push({
-    name: "workflow-tools",
-    tools: createWorkflowTools({
-      runWorkflow: (input) => workflowExecutor.runWorkflow(input),
-      runScript: async () => {
-        throw new Error("workflow_run arrives in phase 2");
-      },
-    }),
-  });
 
   return {
     runId: deps.runId,

--- a/apps/coding-agent/src/core/run-runtime.ts
+++ b/apps/coding-agent/src/core/run-runtime.ts
@@ -373,8 +373,19 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
   let sessionEmit: ((event: CodingAgentLoopEvent) => void) | null = null;
   // The workflow executor rides the SAME model stream + summarizer as the
   // main loop; subagents get the file tools only (no workflow/product tools).
-  // Registered BEFORE createCodingAgentSession: the session snapshots the
-  // plugin tool table at construction time.
+  // Product budget gate (T11a): the Loop freezes its remaining daily budget
+  // on the Run; the executor refuses new spawns once the completed agents'
+  // usage estimate exceeds it. Advisory - the product dailyCap stays the
+  // hard gate. No budget on the run = no gate.
+  let workflowSpentTokens = 0;
+  const workflowBudgetGate = (): { allowed: boolean; reason?: string } => {
+    const budget = activeRun?.workflowBudgetTokens;
+    if (budget == null) return { allowed: true };
+    if (workflowSpentTokens >= budget) {
+      return { allowed: false, reason: "workflow budget exhausted" };
+    }
+    return { allowed: true };
+  };
   const workflowExecutor = createWorkflowExecutor({
     makeSubagentStream: () => streamModel,
     modelId: deps.modelId,
@@ -383,7 +394,21 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
     tools: fileTools,
     workspaceRoot: deps.workspaceRoot,
     workspaceAccess: deps.workspaceAccess,
-    emit: (event) => sessionEmit?.(event),
+    budgetGate: workflowBudgetGate,
+    emit: (event) => {
+      if (event.type === "workflow_agent_completed" && event.usage) {
+        const usage = event.usage;
+        if (typeof usage === "object") {
+          const tokens = (v: unknown): number => (typeof v === "number" && v > 0 ? v : 0);
+          workflowSpentTokens +=
+            tokens((usage as Record<string, unknown>).inputTokens) +
+            tokens((usage as Record<string, unknown>).outputTokens) +
+            tokens((usage as Record<string, unknown>).cacheReadTokens) +
+            tokens((usage as Record<string, unknown>).cacheWriteTokens);
+        }
+      }
+      sessionEmit?.(event);
+    },
     maxConcurrent: 8,
     maxTotal: 64,
   });

--- a/apps/coding-agent/src/core/run-runtime.ts
+++ b/apps/coding-agent/src/core/run-runtime.ts
@@ -1,3 +1,5 @@
+import type { AIMessageChunk } from "@my-agent-team/core";
+
 import {
   type CodingAgentLoopEvent,
   type CodingAgentSession,
@@ -33,6 +35,8 @@ import {
 } from "@my-agent-team/tools-common";
 import { fakeProvider } from "./fake-provider.js";
 import { mountWorkspaceMcpServers } from "./mcp-mount.js";
+import { createWorkflowExecutor } from "./workflow-executor.js";
+import { createWorkflowTools } from "./workflow-tools.js";
 import type { ProductToolCaller } from "./product-tool-transport.js";
 import { readProductToolsManifest } from "./product-tools-manifest.js";
 import { loadRuntimeCatalog, registerProvidersFromCatalog } from "./runtime-catalog.js";
@@ -120,7 +124,7 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
   if (!currentModel) {
     throw new Error(`model not found in catalog: ${deps.modelId}`);
   }
-  const tools: PluginTool[] = [
+  const fileTools: PluginTool[] = [
     createReadTool({ cwd: deps.workspaceRoot }) as unknown as PluginTool,
     createLsTool({ cwd: deps.workspaceRoot }) as unknown as PluginTool,
     createTreeTool({ cwd: deps.workspaceRoot }) as unknown as PluginTool,
@@ -128,9 +132,9 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
     createGrepTool({ workspaceRoot: deps.workspaceRoot }) as unknown as PluginTool,
   ];
   if (deps.workspaceAccess === "read_write") {
-    tools.push(createWriteTool({ cwd: deps.workspaceRoot }) as unknown as PluginTool);
-    tools.push(createEditTool({ cwd: deps.workspaceRoot }) as unknown as PluginTool);
-    tools.push(createBashTool({ workspaceRoot: deps.workspaceRoot }) as unknown as PluginTool);
+    fileTools.push(createWriteTool({ cwd: deps.workspaceRoot }) as unknown as PluginTool);
+    fileTools.push(createEditTool({ cwd: deps.workspaceRoot }) as unknown as PluginTool);
+    fileTools.push(createBashTool({ workspaceRoot: deps.workspaceRoot }) as unknown as PluginTool);
   }
   // Generic .mcp.json mounting (ADR 0022): user servers + knowledge.
   // Skips "product-tools" (the manifest path owns it) and names that
@@ -139,13 +143,13 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
     ...(await mountWorkspaceMcpServers(deps.workspaceRoot, new Set(tools.map((t) => t.name)))),
   );
   if (deps.webSearch) {
-    tools.push(createPortWebSearchTool(deps.webSearch) as unknown as PluginTool);
+    fileTools.push(createPortWebSearchTool(deps.webSearch) as unknown as PluginTool);
   }
   if (deps.webFetch) {
-    tools.push(createPortWebFetchTool(deps.webFetch) as unknown as PluginTool);
+    fileTools.push(createPortWebFetchTool(deps.webFetch) as unknown as PluginTool);
   }
 
-  const nativeToolsPlugin: Plugin = { name: "native-tools", tools };
+  const nativeToolsPlugin: Plugin = { name: "native-tools", tools: fileTools };
   const plugins: Plugin[] = [
     nativeToolsPlugin,
     createRecapPlugin({
@@ -374,6 +378,56 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
     signal: new AbortController().signal,
   };
 
+  // Hoisted so both the main session and workflow subagent sessions share it.
+  async function* streamModel(
+    messages: readonly Message[],
+    signal?: AbortSignal,
+    tools?: readonly PluginTool[],
+  ): AsyncIterable<AIMessageChunk> {
+    const run = activeRun;
+    if (!run) throw new Error("no active run: model unresolved");
+    const catalog = await deps.modelRuntime.getCatalog();
+    const model = catalog.models.find(
+      (m) => `${m.providerId}/${m.modelId}` === resolveModelAlias(run.model.modelId),
+    );
+    if (!model) throw new Error(`model not found: ${run.model.modelId}`);
+    const timeoutSignal = AbortSignal.timeout(modelTimeoutMs);
+    const combined = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+    const reasoningEffort = (run.model as { reasoningEffort?: string }).reasoningEffort;
+    const reasoningOpts =
+      reasoningEffort === "none"
+        ? { thinking: { type: "disabled" as const } }
+        : reasoningEffort === "low" || reasoningEffort === "high" || reasoningEffort === "max"
+          ? {
+              thinking: { type: "adaptive" as const, display: "summarized" as const },
+              effort: (reasoningEffort === "max" ? "xhigh" : reasoningEffort) as
+                | "low"
+                | "high"
+                | "xhigh",
+            }
+          : {};
+    const stream = deps.modelRuntime.stream(model.providerId, model.modelId, messages, {
+      signal: combined,
+      cacheControl: true,
+      ...reasoningOpts,
+      tools: tools?.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    });
+    const iter = stream[Symbol.asyncIterator]();
+    try {
+      for (;;) {
+        const next = await nextBounded(iter, combined, timeoutSignal);
+        if (next.done) return;
+        yield next.value;
+      }
+    } finally {
+      if (!combined.aborted) await iter.return?.().catch(() => {});
+    }
+  }
+
   const session = createCodingAgentSession({
     sessionId: deps.runId,
     store,
@@ -381,60 +435,7 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
     pluginRuntime,
     maxSteps: 32,
     maxForceContinues: 4,
-    modelStream: async function* (messages, signal, tools) {
-      const run = activeRun;
-      if (!run) throw new Error("no active run: model unresolved");
-      const catalog = await deps.modelRuntime.getCatalog();
-      const model = catalog.models.find(
-        (m) => `${m.providerId}/${m.modelId}` === resolveModelAlias(run.model.modelId),
-      );
-      if (!model) throw new Error(`model not found: ${run.model.modelId}`);
-      const timeoutSignal = AbortSignal.timeout(modelTimeoutMs);
-      const combined = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
-      // Reasoning effort from the run config: none disables thinking;
-      // low/high/max use adaptive thinking with the matching effort.
-      const reasoningEffort = (run.model as { reasoningEffort?: string }).reasoningEffort;
-      const reasoningOpts =
-        reasoningEffort === "none"
-          ? { thinking: { type: "disabled" as const } }
-          : reasoningEffort === "low" || reasoningEffort === "high" || reasoningEffort === "max"
-            ? {
-                thinking: { type: "adaptive" as const, display: "summarized" as const },
-                // ponytail: DB may carry "max" from older agent records;
-                // map to "xhigh" (our canonical highest level).
-                effort: (reasoningEffort === "max" ? "xhigh" : reasoningEffort) as
-                  | "low"
-                  | "high"
-                  | "xhigh",
-              }
-            : {};
-      const stream = deps.modelRuntime.stream(model.providerId, model.modelId, messages, {
-        signal: combined,
-        // Prompt caching: ephemeral cache breakpoints on the system prompt
-        // and the last tool definition. Endpoints that don't support
-        // caching silently ignore the breakpoint.
-        cacheControl: true,
-        ...reasoningOpts,
-        // Providers only consume the schema fields; execution happens in
-        // the loop via toolMap. Explicit mapping keeps PluginTool's
-        // richer execute contract out of the provider boundary.
-        tools: tools?.map((t) => ({
-          name: t.name,
-          description: t.description,
-          inputSchema: t.inputSchema,
-        })),
-      });
-      const iter = stream[Symbol.asyncIterator]();
-      try {
-        for (;;) {
-          const next = await nextBounded(iter, combined, timeoutSignal);
-          if (next.done) return;
-          yield next.value;
-        }
-      } finally {
-        if (!combined.aborted) await iter.return?.().catch(() => {});
-      }
-    },
+    modelStream: streamModel,
     summarize,
     contextBudget,
     resolveModel,
@@ -443,6 +444,29 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
 
   // Bind the plugin runtime's emit to the session's emit (two-phase init).
   sessionEmit = (event) => session.emit(event);
+  // The workflow executor rides the SAME model stream + summarizer as the
+  // main loop; subagents get the file tools only (no workflow/product tools).
+  const workflowExecutor = createWorkflowExecutor({
+    makeSubagentStream: () => streamModel,
+    modelId: deps.modelId,
+    summarize,
+    contextBudget,
+    tools: fileTools,
+    workspaceRoot: deps.workspaceRoot,
+    workspaceAccess: deps.workspaceAccess,
+    maxConcurrent: 8,
+    maxTotal: 64,
+    emit: (event) => sessionEmit?.(event as never),
+  });
+  plugins.push({
+    name: "workflow-tools",
+    tools: createWorkflowTools({
+      runWorkflow: (input) => workflowExecutor.runWorkflow(input),
+      runScript: async () => {
+        throw new Error("workflow_run arrives in phase 2");
+      },
+    }),
+  });
 
   return {
     runId: deps.runId,

--- a/apps/coding-agent/src/core/run-runtime.ts
+++ b/apps/coding-agent/src/core/run-runtime.ts
@@ -1,5 +1,3 @@
-import type { AIMessageChunk } from "@my-agent-team/core";
-
 import {
   type CodingAgentLoopEvent,
   type CodingAgentSession,
@@ -15,6 +13,7 @@ import {
 } from "@my-agent-team/agent";
 import type { AgentRunSnapshot, ProjectedHistoryItem } from "@my-agent-team/agent-backend";
 import { type ModelRuntime, resolveModelAlias } from "@my-agent-team/ai";
+import type { AIMessageChunk } from "@my-agent-team/core";
 import type { Message } from "@my-agent-team/message";
 import { createProgressiveSkillPlugin } from "@my-agent-team/plugin-progressive-skill";
 import { createRecapPlugin } from "@my-agent-team/plugin-recap";
@@ -34,12 +33,12 @@ import {
   type WebSearchPort,
 } from "@my-agent-team/tools-common";
 import { fakeProvider } from "./fake-provider.js";
-import { mountWorkspaceMcpServers } from "./mcp-mount.js";
-import { createWorkflowExecutor } from "./workflow-executor.js";
-import { createWorkflowTools } from "./workflow-tools.js";
+
 import type { ProductToolCaller } from "./product-tool-transport.js";
 import { readProductToolsManifest } from "./product-tools-manifest.js";
 import { loadRuntimeCatalog, registerProvidersFromCatalog } from "./runtime-catalog.js";
+import { createWorkflowExecutor } from "./workflow-executor.js";
+import { createWorkflowTools } from "./workflow-tools.js";
 
 /** Token estimation via content char/4 (≈1 token per 4 chars of English/code).
  *  More accurate than JSON.stringify char/4 which includes ~30% syntax

--- a/apps/coding-agent/src/core/run-runtime.ts
+++ b/apps/coding-agent/src/core/run-runtime.ts
@@ -377,9 +377,9 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
     tools: fileTools,
     workspaceRoot: deps.workspaceRoot,
     workspaceAccess: deps.workspaceAccess,
+    emit: (event) => sessionEmit?.(event),
     maxConcurrent: 8,
     maxTotal: 64,
-    emit: (event) => sessionEmit?.(event as never),
   });
   plugins.push({
     name: "workflow-tools",

--- a/apps/coding-agent/src/core/run-runtime.ts
+++ b/apps/coding-agent/src/core/run-runtime.ts
@@ -1,3 +1,7 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
 import {
   type CodingAgentLoopEvent,
   type CodingAgentSession,
@@ -37,15 +41,16 @@ import { fakeProvider } from "./fake-provider.js";
 import type { ProductToolCaller } from "./product-tool-transport.js";
 import { readProductToolsManifest } from "./product-tools-manifest.js";
 import { loadRuntimeCatalog, registerProvidersFromCatalog } from "./runtime-catalog.js";
-import { createWorkflowExecutor } from "./workflow-executor.js";
+import { createWorkflowExecutor, type WorkflowAgentResult } from "./workflow-executor.js";
+import { evaluateWorkflowScript } from "./workflow-evaluator.js";
 import { createWorkflowTools } from "./workflow-tools.js";
-
-/** Token estimation via content char/4 (≈1 token per 4 chars of English/code).
- *  More accurate than JSON.stringify char/4 which includes ~30% syntax
- *  overhead from key names, quotes, braces. Counts actual text + block
- *  content, adds a fixed overhead per message for role/structure framing.
- *  Swap for a real tokenizer (tiktoken, provider SDK) by replacing this
- *  function — the ContextBudget.estimate interface is the extension point. */
+/** Token estimation via content char/4 (approx 1 token per 4 chars of
+ *  English/code). More accurate than JSON.stringify char/4 which includes
+ *  ~30% syntax overhead from key names, quotes, braces. Counts actual text +
+ *  block content, adds a fixed overhead per message for role/structure
+ *  framing. Swap for a real tokenizer (tiktoken, provider SDK) by replacing
+ *  this function — the ContextBudget.estimate interface is the extension
+ *  point. */
 function estimateMessageTokens(message: Message): number {
   let chars = message.text?.length ?? 0;
   if (message.blocks) {
@@ -381,12 +386,69 @@ export async function assembleRunRuntime(deps: RunRuntimeDeps): Promise<RunRunti
     maxConcurrent: 8,
     maxTotal: 64,
   });
+  // Script runs: one workflowId shared by every agent() the script spawns.
+  // The vm evaluator has no fs/network; the executor enforces caps/budget.
+  const runScript = async ({
+    script,
+    args,
+  }: {
+    script: string;
+    args?: unknown;
+  }): Promise<{ ok: boolean; totalTokens: number; value: unknown }> => {
+    const workflowId = `wf-${Date.now().toString(36)}`;
+    const results: WorkflowAgentResult[] = [];
+    sessionEmit?.({
+      type: "workflow_started",
+      workflowId,
+      label: "script",
+      agentCount: 0,
+    });
+    const { value } = await evaluateWorkflowScript({
+      script,
+      args,
+      primitives: {
+        agent: async (prompt, opts) => {
+          const result = await workflowExecutor.runSubagent({
+            workflowId,
+            agentId: randomUUID(),
+            prompt,
+            ...(opts?.schema ? { schema: opts.schema } : {}),
+            ...(opts?.label ? { label: opts.label } : {}),
+          });
+          results.push(result);
+          return result;
+        },
+        pipeline: (items, fn) => Promise.all(items.map(fn)),
+      },
+    });
+    const totalTokens = results.reduce(
+      (acc, r) =>
+        acc +
+        (r.usage?.inputTokens ?? 0) +
+        (r.usage?.outputTokens ?? 0) +
+        (r.usage?.cacheReadTokens ?? 0) +
+        (r.usage?.cacheWriteTokens ?? 0),
+      0,
+    );
+    const ok = results.every((r) => r.ok);
+    sessionEmit?.({
+      type: "workflow_completed",
+      workflowId,
+      ok,
+      agentCount: results.length,
+      totalTokens,
+    });
+    return { ok, totalTokens, value };
+  };
   plugins.push({
     name: "workflow-tools",
     tools: createWorkflowTools({
       runWorkflow: (input) => workflowExecutor.runWorkflow(input),
-      runScript: async () => {
-        throw new Error("workflow_run arrives in phase 2");
+      runScript,
+      writeScript: (name, content) => {
+        const dir = join(deps.workspaceRoot, ".workflows");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, `${name}.js`), content);
       },
     }),
   });

--- a/apps/coding-agent/src/core/run-runtime.ts
+++ b/apps/coding-agent/src/core/run-runtime.ts
@@ -41,9 +41,10 @@ import { fakeProvider } from "./fake-provider.js";
 import type { ProductToolCaller } from "./product-tool-transport.js";
 import { readProductToolsManifest } from "./product-tools-manifest.js";
 import { loadRuntimeCatalog, registerProvidersFromCatalog } from "./runtime-catalog.js";
-import { createWorkflowExecutor, type WorkflowAgentResult } from "./workflow-executor.js";
 import { evaluateWorkflowScript } from "./workflow-evaluator.js";
+import { createWorkflowExecutor, type WorkflowAgentResult } from "./workflow-executor.js";
 import { createWorkflowTools } from "./workflow-tools.js";
+
 /** Token estimation via content char/4 (approx 1 token per 4 chars of
  *  English/code). More accurate than JSON.stringify char/4 which includes
  *  ~30% syntax overhead from key names, quotes, braces. Counts actual text +

--- a/apps/coding-agent/src/core/workflow-evaluator.test.ts
+++ b/apps/coding-agent/src/core/workflow-evaluator.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { evaluateWorkflowScript } from "./workflow-evaluator.js";
+
+const primitives = {
+  agent: async (prompt: string) => ({
+    text: `echo:${prompt}`,
+    output: undefined,
+    ok: true,
+    label: "",
+  }),
+  pipeline: async (items: readonly unknown[], fn: (item: unknown) => Promise<unknown>) =>
+    Promise.all(items.map(fn)),
+};
+
+describe("evaluateWorkflowScript", () => {
+  test("runs top-level await scripts with agent + pipeline", async () => {
+    const result = await evaluateWorkflowScript({
+      script:
+        'const found = await agent("find"); const all = await pipeline([1, 2], (x) => agent(String(x))); return all.length;',
+      args: undefined,
+      primitives: primitives as never,
+    });
+    expect(result.value).toBe(2);
+  });
+
+  test("args are passed as a global", async () => {
+    const result = await evaluateWorkflowScript({
+      script: "return args.count * 2;",
+      args: { count: 21 },
+      primitives: primitives as never,
+    });
+    expect(result.value).toBe(42);
+  });
+
+  test("fs/process/require are absent inside the sandbox", async () => {
+    // typeof never throws for undeclared names: the value proves absence.
+    const processType = await evaluateWorkflowScript({
+      script: "return typeof process;",
+      args: undefined,
+      primitives: primitives as never,
+    });
+    expect(processType.value).toBe("undefined");
+    const requireType = await evaluateWorkflowScript({
+      script: "return typeof require;",
+      args: undefined,
+      primitives: primitives as never,
+    });
+    expect(requireType.value).toBe("undefined");
+    // Direct access throws.
+    await expect(
+      evaluateWorkflowScript({
+        script: "return process;",
+        args: undefined,
+        primitives: primitives as never,
+      }),
+    ).rejects.toThrow(/process is not defined/);
+  });
+
+  test("the timeout aborts a synchronous infinite loop", async () => {
+    await expect(
+      evaluateWorkflowScript({
+        script: "while (true) {}",
+        args: undefined,
+        primitives: primitives as never,
+        timeoutMs: 50,
+      }),
+    ).rejects.toThrow(/timed out|Script execution timed out/);
+  });
+
+  test("the timeout races an async stall", async () => {
+    await expect(
+      evaluateWorkflowScript({
+        script: "await new Promise(() => {});",
+        args: undefined,
+        primitives: primitives as never,
+        timeoutMs: 50,
+      }),
+    ).rejects.toThrow(/timed out/);
+  });
+});

--- a/apps/coding-agent/src/core/workflow-evaluator.ts
+++ b/apps/coding-agent/src/core/workflow-evaluator.ts
@@ -1,0 +1,43 @@
+import vm from "node:vm";
+
+export interface WorkflowPrimitives {
+  readonly agent: (
+    prompt: string,
+    opts?: { schema?: Readonly<Record<string, unknown>>; label?: string },
+  ) => Promise<unknown>;
+  readonly pipeline: (
+    items: readonly unknown[],
+    fn: (item: unknown) => Promise<unknown>,
+    opts?: { concurrency?: number },
+  ) => Promise<readonly unknown[]>;
+}
+
+export interface EvaluateResult {
+  readonly value: unknown;
+}
+
+/** Sandboxed script evaluation: ONLY agent/pipeline/args are injected.
+ *  require/process/fs/fetch do not exist inside the script. The vm timeout
+ *  covers synchronous infinite loops; the caller races the returned promise
+ *  against the script budget for async stalls. */
+export async function evaluateWorkflowScript(input: {
+  readonly script: string;
+  readonly args?: unknown;
+  readonly primitives: WorkflowPrimitives;
+  readonly timeoutMs?: number;
+}): Promise<EvaluateResult> {
+  const timeoutMs = input.timeoutMs ?? 60_000;
+  const { agent, pipeline } = input.primitives;
+  const context = vm.createContext(
+    { agent, pipeline, args: input.args },
+    { name: "workflow-script" },
+  );
+  const wrapped = `(async () => { ${input.script} })()`;
+  const promise = vm.runInContext(wrapped, context, { timeout: timeoutMs }) as Promise<unknown>;
+  const timer = new Promise<never>((_, reject) => {
+    const id = setTimeout(() => reject(new Error("workflow script timed out")), timeoutMs);
+    void promise.finally(() => clearTimeout(id)).catch(() => {});
+  });
+  const value = await Promise.race([promise, timer]);
+  return { value };
+}

--- a/apps/coding-agent/src/core/workflow-executor.test.ts
+++ b/apps/coding-agent/src/core/workflow-executor.test.ts
@@ -111,4 +111,25 @@ describe("createWorkflowExecutor", () => {
     expect(result.ok).toBe(false);
     expect(result.error).toContain("not valid JSON");
   });
+  test("a rejected spawn releases its concurrency slot (no deadlock)", async () => {
+    let allow = false;
+    const exec = createWorkflowExecutor({
+      ...makeDeps(),
+      maxConcurrent: 1,
+      budgetGate: () =>
+        allow ? { allowed: true } : { allowed: false, reason: "budget exhausted" },
+    });
+    await expect(
+      exec.runWorkflow({ workflowId: "wf6", label: "denied", items: [{ prompt: "p1" }] }),
+    ).rejects.toThrow(/budget exhausted/);
+    // The rejected spawn released its slot; a later allowed run completes
+    // instead of deadlocking on the leaked acquire.
+    allow = true;
+    const result = await exec.runWorkflow({
+      workflowId: "wf7",
+      label: "ok",
+      items: [{ prompt: "p2" }],
+    });
+    expect(result.ok).toBe(true);
+  });
 });

--- a/apps/coding-agent/src/core/workflow-executor.test.ts
+++ b/apps/coding-agent/src/core/workflow-executor.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createEchoModelStream } from "./__fixtures__/echo-model.js";
+import { createWorkflowExecutor } from "./workflow-executor.js";
+
+const events: Array<{ type: string }> = [];
+const emit = (e: unknown): void => {
+  events.push(e as { type: string });
+};
+
+function makeDeps() {
+  return {
+    makeSubagentStream: (sessionId: string) => createEchoModelStream(`echo:${sessionId}`),
+    modelId: "fake/echo",
+    summarize: async () => "[summary]",
+    contextBudget: { estimate: () => 0, limit: 100_000, triggerRatio: 0.7 },
+    tools: [],
+    workspaceRoot: "/tmp/wf-test",
+    workspaceAccess: "read_only" as const,
+    maxConcurrent: 2,
+    maxTotal: 4,
+    emit,
+  };
+}
+
+describe("createWorkflowExecutor", () => {
+  afterEach(() => {
+    events.length = 0;
+  });
+
+  test("runWorkflow fans out and aggregates with lifecycle events", async () => {
+    const exec = createWorkflowExecutor(makeDeps());
+    const result = await exec.runWorkflow({
+      workflowId: "wf1",
+      label: "audit",
+      items: [
+        { prompt: "one", label: "a" },
+        { prompt: "two", label: "b" },
+        { prompt: "three", label: "c" },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    expect(result.items.map((i) => i.text)).toEqual([
+      "echo:wf:wf1:a0",
+      "echo:wf:wf1:a1",
+      "echo:wf:wf1:a2",
+    ]);
+    expect(events.filter((e) => e.type === "workflow_agent_started")).toHaveLength(3);
+    expect(events.filter((e) => e.type === "workflow_agent_completed")).toHaveLength(3);
+    const started = events.find((e) => e.type === "workflow_started") as {
+      agentCount: number;
+    };
+    expect(started.agentCount).toBe(3);
+    const done = events.find((e) => e.type === "workflow_completed") as { ok: boolean };
+    expect(done.ok).toBe(true);
+  });
+
+  test("the total cap rejects excess agents with a clear error", async () => {
+    const exec = createWorkflowExecutor(makeDeps());
+    await expect(
+      exec.runWorkflow({
+        workflowId: "wf2",
+        label: "big",
+        items: Array.from({ length: 5 }, (_, i) => ({ prompt: `p${i}` })),
+      }),
+    ).rejects.toThrow(/4-agent cap/);
+  });
+
+  test("a budget gate can refuse new spawns", async () => {
+    let budget = 2;
+    const exec = createWorkflowExecutor({
+      ...makeDeps(),
+      budgetGate: () =>
+        --budget >= 0 ? { allowed: true } : { allowed: false, reason: "budget exhausted" },
+    });
+    await expect(
+      exec.runWorkflow({
+        workflowId: "wf3",
+        label: "gated",
+        items: [1, 2, 3].map((i) => ({ prompt: `p${i}` })),
+      }),
+    ).rejects.toThrow(/budget exhausted/);
+  });
+
+  test("schema output is parsed from the final JSON text", async () => {
+    const exec = createWorkflowExecutor({
+      ...makeDeps(),
+      makeSubagentStream: () => createEchoModelStream('{"ok":true}'),
+    });
+    const result = await exec.runSubagent({
+      workflowId: "wf4",
+      agentId: "a1",
+      prompt: "return json",
+      label: "x",
+      schema: { type: "object" },
+    });
+    expect(result.output).toEqual({ ok: true });
+    expect(result.ok).toBe(true);
+  });
+
+  test("malformed schema output marks the agent failed with the error", async () => {
+    const exec = createWorkflowExecutor({
+      ...makeDeps(),
+      makeSubagentStream: () => createEchoModelStream("not json at all"),
+    });
+    const result = await exec.runSubagent({
+      workflowId: "wf5",
+      agentId: "a1",
+      prompt: "return json",
+      schema: { type: "object" },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("not valid JSON");
+  });
+});

--- a/apps/coding-agent/src/core/workflow-executor.ts
+++ b/apps/coding-agent/src/core/workflow-executor.ts
@@ -1,0 +1,246 @@
+import type { AIMessageChunk } from "@my-agent-team/core";
+import {
+  createCodingAgentSession,
+  createInMemorySessionStore,
+  type ContextBudget,
+  type ContextSummarizer,
+  type PluginTool,
+} from "@my-agent-team/agent";
+import type { Usage } from "@my-agent-team/agent-backend";
+import type { Message } from "@my-agent-team/message";
+
+export interface WorkflowAgentSpec {
+  readonly prompt: string;
+  readonly label?: string;
+  readonly schema?: Readonly<Record<string, unknown>>;
+}
+
+export interface WorkflowAgentResult {
+  readonly label: string;
+  readonly text: string;
+  readonly output?: unknown;
+  readonly ok: boolean;
+  readonly error?: string;
+  readonly usage?: Usage;
+}
+
+export interface WorkflowRunResult {
+  readonly items: readonly WorkflowAgentResult[];
+  readonly totalTokens: number;
+  readonly ok: boolean;
+}
+
+/** Same shape as the session's modelStream option: the subagent session calls
+ *  it with its own messages/signal/tools. */
+export type SubagentModelStream = (
+  messages: readonly Message[],
+  signal?: AbortSignal,
+  tools?: readonly PluginTool[],
+) => AsyncIterable<AIMessageChunk>;
+
+export interface WorkflowExecutorOptions {
+  /** Build the subagent model stream (same model + reasoning as the run). */
+  readonly makeSubagentStream: (sessionId: string) => SubagentModelStream;
+  readonly modelId: string;
+  readonly summarize: ContextSummarizer;
+  readonly contextBudget: ContextBudget;
+  /** File tools only (no workflow/product tools - recursion + clobber guards). */
+  readonly tools: readonly PluginTool[];
+  readonly workspaceRoot: string;
+  readonly workspaceAccess: "read_only" | "read_write";
+  readonly maxConcurrent: number;
+  readonly maxTotal: number;
+  readonly emit: (event: unknown) => void;
+  /** Optional product budget gate: consulted BEFORE each spawn. */
+  readonly budgetGate?: () => { allowed: boolean; reason?: string };
+}
+
+export interface WorkflowExecutor {
+  runSubagent(
+    input: { workflowId: string; agentId: string } & WorkflowAgentSpec,
+    signal?: AbortSignal,
+  ): Promise<WorkflowAgentResult>;
+  runWorkflow(input: {
+    workflowId: string;
+    label: string;
+    items: readonly WorkflowAgentSpec[];
+    signal?: AbortSignal;
+  }): Promise<WorkflowRunResult>;
+}
+
+const SUBAGENT_SYSTEM_PROMPT =
+  "You are a subagent of a coding agent run. Complete the given task and stop. " +
+  "Return only the result text (or JSON when a schema is requested).";
+
+export function createWorkflowExecutor(opts: WorkflowExecutorOptions): WorkflowExecutor {
+  let totalSpawned = 0;
+  let current = 0;
+  const waiters: Array<() => void> = [];
+
+  async function acquire(): Promise<void> {
+    if (current < opts.maxConcurrent) {
+      current++;
+      return;
+    }
+    await new Promise<void>((resolve) => waiters.push(resolve));
+  }
+  function release(): void {
+    const next = waiters.shift();
+    if (next) next();
+    else current--;
+  }
+
+  function gate(): void {
+    if (totalSpawned >= opts.maxTotal) {
+      throw new Error(`workflow exceeds the ${opts.maxTotal}-agent cap`);
+    }
+    if (opts.budgetGate) {
+      const decision = opts.budgetGate();
+      if (!decision.allowed) throw new Error(decision.reason ?? "workflow budget exhausted");
+    }
+    totalSpawned++;
+  }
+
+  async function runSubagent(
+    input: { workflowId: string; agentId: string } & WorkflowAgentSpec,
+    signal?: AbortSignal,
+  ): Promise<WorkflowAgentResult> {
+    await acquire();
+    gate();
+    const label = input.label ?? input.agentId;
+    const sessionId = `wf:${input.workflowId}:${input.agentId}`;
+    opts.emit({
+      type: "workflow_agent_started",
+      workflowId: input.workflowId,
+      agentId: input.agentId,
+      label,
+    });
+    try {
+      const store = createInMemorySessionStore();
+      // The loop opens the session record on startLoop: seed it first
+      // (same contract as the run runtime's create-runtime.ts).
+      await store.create({
+        sessionId,
+        backendKind: "coding_agent",
+        workspaceRoot: opts.workspaceRoot,
+        leafEntryId: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      const session = createCodingAgentSession({
+        sessionId,
+        store,
+        plugins: [{ name: "subagent-tools", tools: opts.tools }],
+        maxSteps: 8,
+        maxForceContinues: 2,
+        modelStream: opts.makeSubagentStream(sessionId),
+        summarize: opts.summarize,
+        contextBudget: opts.contextBudget,
+      });
+      const onAbort = (): void => session.stop();
+      signal?.addEventListener("abort", onAbort, { once: true });
+      let result;
+      try {
+        result = await session.startLoop({
+          history: [],
+          input: {
+            inputId: input.agentId,
+            message: { role: "user", text: input.prompt },
+          },
+          run: {
+            runId: sessionId,
+            model: { backendKind: "coding_agent", modelId: opts.modelId },
+            systemPrompt: SUBAGENT_SYSTEM_PROMPT,
+            productTools: [],
+            configRevision: 0,
+          },
+          workspace: { root: opts.workspaceRoot, access: opts.workspaceAccess },
+          metadata: { conversationId: "", agentMemberId: "", branchId: "" },
+        });
+      } finally {
+        signal?.removeEventListener("abort", onAbort);
+      }
+      void store.close().catch(() => {});
+      const text = (result.messages?.at(-1)?.text ?? "").trim();
+      let output: unknown;
+      let parseError: string | undefined;
+      if (input.schema && text) {
+        try {
+          output = JSON.parse(text);
+        } catch {
+          parseError = `schema output is not valid JSON: ${text.slice(0, 120)}`;
+        }
+      }
+      const agentResult: WorkflowAgentResult = {
+        label,
+        text,
+        ok: result.status === "completed" && !parseError,
+        ...(output !== undefined ? { output } : {}),
+        ...(parseError ? { error: parseError } : {}),
+        ...(result.usage ? { usage: result.usage } : {}),
+      };
+      opts.emit({
+        type: "workflow_agent_completed",
+        workflowId: input.workflowId,
+        agentId: input.agentId,
+        label,
+        ok: agentResult.ok,
+        ...(agentResult.error ? { error: agentResult.error } : {}),
+        ...(agentResult.usage ? { usage: agentResult.usage } : {}),
+      });
+      return agentResult;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      opts.emit({
+        type: "workflow_agent_completed",
+        workflowId: input.workflowId,
+        agentId: input.agentId,
+        label,
+        ok: false,
+        error: message,
+      });
+      return { label, text: "", ok: false, error: message };
+    } finally {
+      release();
+    }
+  }
+
+  async function runWorkflow(input: {
+    workflowId: string;
+    label: string;
+    items: readonly WorkflowAgentSpec[];
+    signal?: AbortSignal;
+  }): Promise<WorkflowRunResult> {
+    opts.emit({
+      type: "workflow_started",
+      workflowId: input.workflowId,
+      label: input.label,
+      agentCount: input.items.length,
+    });
+    const results = await Promise.all(
+      input.items.map((item, i) =>
+        runSubagent({ workflowId: input.workflowId, agentId: `a${i}`, ...item }, input.signal),
+      ),
+    );
+    const totalTokens = results.reduce(
+      (acc, r) =>
+        acc +
+        (r.usage?.inputTokens ?? 0) +
+        (r.usage?.outputTokens ?? 0) +
+        (r.usage?.cacheReadTokens ?? 0) +
+        (r.usage?.cacheWriteTokens ?? 0),
+      0,
+    );
+    const ok = results.every((r) => r.ok);
+    opts.emit({
+      type: "workflow_completed",
+      workflowId: input.workflowId,
+      ok,
+      agentCount: input.items.length,
+      totalTokens,
+    });
+    return { items: results, totalTokens, ok };
+  }
+
+  return { runSubagent, runWorkflow };
+}

--- a/apps/coding-agent/src/core/workflow-executor.ts
+++ b/apps/coding-agent/src/core/workflow-executor.ts
@@ -1,12 +1,12 @@
-import type { AIMessageChunk } from "@my-agent-team/core";
 import {
-  createCodingAgentSession,
-  createInMemorySessionStore,
   type ContextBudget,
   type ContextSummarizer,
+  createCodingAgentSession,
+  createInMemorySessionStore,
   type PluginTool,
 } from "@my-agent-team/agent";
 import type { Usage } from "@my-agent-team/agent-backend";
+import type { AIMessageChunk } from "@my-agent-team/core";
 import type { Message } from "@my-agent-team/message";
 
 export interface WorkflowAgentSpec {

--- a/apps/coding-agent/src/core/workflow-executor.ts
+++ b/apps/coding-agent/src/core/workflow-executor.ts
@@ -1,10 +1,10 @@
 import {
-  createCodingAgentSession,
-  createInMemorySessionStore,
   type CodingAgentLoopEvent,
   type CodingAgentSession,
   type ContextBudget,
   type ContextSummarizer,
+  createCodingAgentSession,
+  createInMemorySessionStore,
   type PluginTool,
 } from "@my-agent-team/agent";
 import type { Usage } from "@my-agent-team/agent-backend";

--- a/apps/coding-agent/src/core/workflow-executor.ts
+++ b/apps/coding-agent/src/core/workflow-executor.ts
@@ -1,9 +1,10 @@
 import {
+  createCodingAgentSession,
+  createInMemorySessionStore,
+  type CodingAgentLoopEvent,
   type CodingAgentSession,
   type ContextBudget,
   type ContextSummarizer,
-  createCodingAgentSession,
-  createInMemorySessionStore,
   type PluginTool,
 } from "@my-agent-team/agent";
 import type { Usage } from "@my-agent-team/agent-backend";
@@ -51,7 +52,7 @@ export interface WorkflowExecutorOptions {
   readonly workspaceAccess: "read_only" | "read_write";
   readonly maxConcurrent: number;
   readonly maxTotal: number;
-  readonly emit: (event: unknown) => void;
+  readonly emit: (event: CodingAgentLoopEvent) => void;
   /** Optional product budget gate: consulted BEFORE each spawn. */
   readonly budgetGate?: () => { allowed: boolean; reason?: string };
 }
@@ -91,13 +92,17 @@ export function createWorkflowExecutor(opts: WorkflowExecutorOptions): WorkflowE
     else current--;
   }
 
+  class WorkflowGateError extends Error {}
+
   function gate(): void {
     if (totalSpawned >= opts.maxTotal) {
-      throw new Error(`workflow exceeds the ${opts.maxTotal}-agent cap`);
+      throw new WorkflowGateError(`workflow exceeds the ${opts.maxTotal}-agent cap`);
     }
     if (opts.budgetGate) {
       const decision = opts.budgetGate();
-      if (!decision.allowed) throw new Error(decision.reason ?? "workflow budget exhausted");
+      if (!decision.allowed) {
+        throw new WorkflowGateError(decision.reason ?? "workflow budget exhausted");
+      }
     }
     totalSpawned++;
   }
@@ -107,16 +112,19 @@ export function createWorkflowExecutor(opts: WorkflowExecutorOptions): WorkflowE
     signal?: AbortSignal,
   ): Promise<WorkflowAgentResult> {
     await acquire();
-    gate();
-    const label = input.label ?? input.agentId;
-    const sessionId = `wf:${input.workflowId}:${input.agentId}`;
-    opts.emit({
-      type: "workflow_agent_started",
-      workflowId: input.workflowId,
-      agentId: input.agentId,
-      label,
-    });
+    // gate() may throw (cap/budget): it runs inside the try so the acquired
+    // concurrency slot is ALWAYS released - a leak here would deadlock every
+    // later acquire once all slots are gone.
     try {
+      gate();
+      const label = input.label ?? input.agentId;
+      const sessionId = `wf:${input.workflowId}:${input.agentId}`;
+      opts.emit({
+        type: "workflow_agent_started",
+        workflowId: input.workflowId,
+        agentId: input.agentId,
+        label,
+      });
       const store = createInMemorySessionStore();
       // The loop opens the session record on startLoop: seed it first
       // (same contract as the run runtime's create-runtime.ts).
@@ -191,7 +199,11 @@ export function createWorkflowExecutor(opts: WorkflowExecutorOptions): WorkflowE
       });
       return agentResult;
     } catch (err) {
+      // Gate failures (cap/budget) are WORKFLOW-level: propagate so the
+      // whole fan-out rejects instead of degrading to a failed agent row.
+      if (err instanceof WorkflowGateError) throw err;
       const message = err instanceof Error ? err.message : String(err);
+      const label = input.label ?? input.agentId;
       opts.emit({
         type: "workflow_agent_completed",
         workflowId: input.workflowId,

--- a/apps/coding-agent/src/core/workflow-executor.ts
+++ b/apps/coding-agent/src/core/workflow-executor.ts
@@ -1,4 +1,5 @@
 import {
+  type CodingAgentSession,
   type ContextBudget,
   type ContextSummarizer,
   createCodingAgentSession,
@@ -139,7 +140,7 @@ export function createWorkflowExecutor(opts: WorkflowExecutorOptions): WorkflowE
       });
       const onAbort = (): void => session.stop();
       signal?.addEventListener("abort", onAbort, { once: true });
-      let result;
+      let result: Awaited<ReturnType<CodingAgentSession["startLoop"]>>;
       try {
         result = await session.startLoop({
           history: [],

--- a/apps/coding-agent/src/core/workflow-executor.ts
+++ b/apps/coding-agent/src/core/workflow-executor.ts
@@ -160,7 +160,6 @@ export function createWorkflowExecutor(opts: WorkflowExecutorOptions): WorkflowE
             runId: sessionId,
             model: { backendKind: "coding_agent", modelId: opts.modelId },
             systemPrompt: SUBAGENT_SYSTEM_PROMPT,
-            productTools: [],
             configRevision: 0,
           },
           workspace: { root: opts.workspaceRoot, access: opts.workspaceAccess },

--- a/apps/coding-agent/src/core/workflow-tools.ts
+++ b/apps/coding-agent/src/core/workflow-tools.ts
@@ -1,0 +1,75 @@
+import type { PluginTool } from "@my-agent-team/agent";
+import type { WorkflowAgentSpec, WorkflowRunResult } from "./workflow-executor.js";
+
+export interface WorkflowToolDeps {
+  readonly runWorkflow: (input: {
+    workflowId: string;
+    label: string;
+    items: readonly WorkflowAgentSpec[];
+    signal?: AbortSignal;
+  }) => Promise<WorkflowRunResult>;
+  /** Phase 2 fills this; Phase 1 passes a throwing stub (run_workflow is the
+   *  only tool until the evaluator lands). */
+  readonly runScript: (input: { script: string; args?: unknown }) => Promise<WorkflowRunResult>;
+}
+
+/** Boundary narrowing: tool args arrive from the model as unknown-shaped
+ *  JSON - validate each field before it enters the executor. */
+function parseItem(raw: unknown): WorkflowAgentSpec {
+  const item = raw as Record<string, unknown>;
+  const schema = item.schema;
+  const schemaRec: Readonly<Record<string, unknown>> | undefined =
+    schema && typeof schema === "object" && !Array.isArray(schema)
+      ? (schema as Readonly<Record<string, unknown>>)
+      : undefined;
+  return {
+    prompt: String(item.prompt ?? ""),
+    ...(typeof item.label === "string" ? { label: item.label } : {}),
+    ...(schemaRec ? { schema: schemaRec } : {}),
+  };
+}
+
+export function createWorkflowTools(deps: WorkflowToolDeps): readonly PluginTool[] {
+  const runWorkflow: PluginTool = {
+    name: "run_workflow",
+    description:
+      "Fan out independent subagent tasks in parallel and aggregate their results. " +
+      "Each item gets its own isolated agent session (same model, file tools). " +
+      "Use for audits, migrations, and multi-source research. " +
+      "Items: [{prompt, schema?, label?}]. Returns per-item text and schema-parsed output.",
+    executionMode: "serial",
+    inputSchema: {
+      type: "object",
+      properties: {
+        label: { type: "string" },
+        concurrency: { type: "number", maximum: 8 },
+        items: {
+          type: "array",
+          maxItems: 64,
+          items: {
+            type: "object",
+            properties: {
+              prompt: { type: "string" },
+              label: { type: "string" },
+              schema: { type: "object" },
+            },
+            required: ["prompt"],
+          },
+        },
+      },
+      required: ["items"],
+    },
+    async execute(args, signal) {
+      const rawItems = Array.isArray(args.items) ? args.items : [];
+      const workflowId = `wf-${Date.now().toString(36)}`;
+      const result = await deps.runWorkflow({
+        workflowId,
+        label: typeof args.label === "string" ? args.label : "workflow",
+        items: rawItems.map(parseItem),
+        ...(signal ? { signal } : {}),
+      });
+      return { items: result.items, totalTokens: result.totalTokens, ok: result.ok };
+    },
+  };
+  return [runWorkflow];
+}

--- a/apps/coding-agent/src/core/workflow-tools.ts
+++ b/apps/coding-agent/src/core/workflow-tools.ts
@@ -1,6 +1,12 @@
 import type { PluginTool } from "@my-agent-team/agent";
 import type { WorkflowAgentSpec, WorkflowRunResult } from "./workflow-executor.js";
 
+export interface WorkflowScriptResult {
+  readonly ok: boolean;
+  readonly totalTokens: number;
+  readonly value: unknown;
+}
+
 export interface WorkflowToolDeps {
   readonly runWorkflow: (input: {
     workflowId: string;
@@ -8,9 +14,10 @@ export interface WorkflowToolDeps {
     items: readonly WorkflowAgentSpec[];
     signal?: AbortSignal;
   }) => Promise<WorkflowRunResult>;
-  /** Phase 2 fills this; Phase 1 passes a throwing stub (run_workflow is the
-   *  only tool until the evaluator lands). */
-  readonly runScript: (input: { script: string; args?: unknown }) => Promise<WorkflowRunResult>;
+  /** Executes an orchestration script in the vm sandbox (Phase 2). */
+  readonly runScript: (input: { script: string; args?: unknown }) => Promise<WorkflowScriptResult>;
+  /** Persist a script to `<workspace>/.workflows/<name>.js` for reuse. */
+  readonly writeScript: (name: string, content: string) => void;
 }
 
 /** Boundary narrowing: tool args arrive from the model as unknown-shaped
@@ -71,5 +78,38 @@ export function createWorkflowTools(deps: WorkflowToolDeps): readonly PluginTool
       return { items: result.items, totalTokens: result.totalTokens, ok: result.ok };
     },
   };
-  return [runWorkflow];
+
+  const runScript: PluginTool = {
+    name: "workflow_run",
+    description:
+      "Run an orchestration script (top-level-await JS) that fans out subagents " +
+      "via agent(prompt, {schema?, label?}) and pipeline(items, fn). Scripts have " +
+      "NO fs/network access - agents do the work. Save reusable scripts with the " +
+      "name argument (written to .workflows/<name>.js).",
+    executionMode: "serial",
+    inputSchema: {
+      type: "object",
+      properties: {
+        script: { type: "string", maxLength: 32768 },
+        name: { type: "string" },
+        args: { type: "object" },
+      },
+      required: ["script"],
+    },
+    async execute(args) {
+      const script = typeof args.script === "string" ? args.script : "";
+      if (typeof args.name === "string" && args.name.length > 0) {
+        deps.writeScript(args.name, script);
+      }
+      const result = await deps.runScript({ script, args: args.args });
+      return {
+        ok: result.ok,
+        totalTokens: result.totalTokens,
+        value: result.value,
+        scriptSaved: typeof args.name === "string" && args.name.length > 0,
+      };
+    },
+  };
+
+  return [runWorkflow, runScript];
 }

--- a/apps/web/src/components/ConversationCanvas.tsx
+++ b/apps/web/src/components/ConversationCanvas.tsx
@@ -22,6 +22,7 @@ import { RecapPanel } from "./RecapPanel";
 import { RosterList } from "./RosterList";
 import { Timeline } from "./Timeline";
 import { TodoPanel } from "./TodoPanel";
+import { WorkflowPanel } from "./WorkflowPanel";
 
 interface ConversationCanvasProps {
   conversationId: string;
@@ -48,6 +49,7 @@ export function ConversationCanvas({
     runTodos,
     runRecaps,
     activeRuns,
+    workflows,
   } = useConversation(conversationId, snapshot);
   const { viewerMemberId, roster, items, error, triggerMode, streamConn } = state;
 
@@ -332,6 +334,8 @@ export function ConversationCanvas({
             : "Reconnecting…"}
         </div>
       )}
+      {/* Workflow progress — transient, per running workflow */}
+      <WorkflowPanel workflows={workflows} />
 
       {/* M14.6: Todo progress — pinned above message stream */}
       <TodoPanel

--- a/apps/web/src/components/WorkflowPanel.tsx
+++ b/apps/web/src/components/WorkflowPanel.tsx
@@ -9,10 +9,11 @@ export function WorkflowPanel({ workflows }: { workflows: ReadonlyMap<string, Wo
     <div className="space-y-2 rounded-lg border bg-card p-3 text-sm">
       {running.map(([workflowId, w]) => {
         const done = [...w.agents.values()].filter((a) => a.status !== "running").length;
+        const total = w.agentCount > 0 ? w.agentCount : w.agents.size;
         return (
           <div key={workflowId}>
             <div className="font-medium">
-              {w.label} · {done}/{w.agentCount} agents
+              {w.label} · {done}/{total} agents
             </div>
             <ul className="mt-1 space-y-0.5">
               {[...w.agents.entries()].map(([agentId, a]) => {

--- a/apps/web/src/components/WorkflowPanel.tsx
+++ b/apps/web/src/components/WorkflowPanel.tsx
@@ -1,0 +1,33 @@
+import type { WorkflowRunState } from "@/hooks/useConversation";
+
+/** Transient workflow progress (Phase 1): one collapsible card per running
+ *  workflow with per-agent status. Durable truth is the tool result message. */
+export function WorkflowPanel({ workflows }: { workflows: ReadonlyMap<string, WorkflowRunState> }) {
+  const running = [...workflows.entries()].filter(([, w]) => w.ok === null);
+  if (running.length === 0) return null;
+  return (
+    <div className="space-y-2 rounded-lg border bg-card p-3 text-sm">
+      {running.map(([workflowId, w]) => {
+        const done = [...w.agents.values()].filter((a) => a.status !== "running").length;
+        return (
+          <div key={workflowId}>
+            <div className="font-medium">
+              {w.label} · {done}/{w.agentCount} agents
+            </div>
+            <ul className="mt-1 space-y-0.5">
+              {[...w.agents.entries()].map(([agentId, a]) => {
+                const mark = a.status === "running" ? "⏳" : a.status === "done" ? "✓" : "✗";
+                return (
+                  <li key={agentId} className={a.status === "failed" ? "text-red-600" : ""}>
+                    {mark} {a.label}
+                    {a.error ? ` — ${a.error.slice(0, 80)}` : ""}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useConversation.ts
+++ b/apps/web/src/hooks/useConversation.ts
@@ -32,6 +32,20 @@ import {
 } from "@/lib/transient-reducer";
 import { typedSource } from "@/lib/typed-source";
 
+/** Transient workflow run progress (SSE-driven; cleared on stream close). */
+export interface WorkflowAgentState {
+  readonly label: string;
+  readonly status: "running" | "done" | "failed";
+  readonly error?: string;
+}
+export interface WorkflowRunState {
+  readonly label: string;
+  readonly agentCount: number;
+  readonly agents: ReadonlyMap<string, WorkflowAgentState>;
+  readonly ok: boolean | null;
+  readonly totalTokens: number;
+}
+
 const RECAP_STORAGE_PREFIX = "mat:recap:";
 
 function safeParse(raw: string): unknown {
@@ -80,6 +94,8 @@ export function useConversation(
   const [runRecaps, setRunRecapsState] = useState<Record<string, { text: string; turn: number }>>(
     {},
   );
+  /** Live workflow runs (transient progress, cleared with the SSE stream). */
+  const [workflows, setWorkflows] = useState<ReadonlyMap<string, WorkflowRunState>>(new Map());
 
   const upsertToolState = useCallback((call: LiveToolCall) => {
     setTransientTools((prev) => upsertTool(prev, call));
@@ -477,6 +493,74 @@ export function useConversation(
           /* malformed - ignore */
         }
       });
+      const upsertWorkflow = (
+        workflowId: string,
+        patch: (w: WorkflowRunState | undefined) => WorkflowRunState | undefined,
+      ): void => {
+        setWorkflows((prev) => {
+          const next = new Map(prev);
+          const updated = patch(prev.get(workflowId));
+          if (updated) next.set(workflowId, updated);
+          else next.delete(workflowId);
+          return next;
+        });
+      };
+      const workflowEvent =
+        (kind: "started" | "agent_started" | "agent_completed" | "completed") => (e: Event) => {
+          try {
+            const ev = JSON.parse((e as MessageEvent).data) as {
+              workflowId?: string;
+              label?: string;
+              agentCount?: number;
+              agentId?: string;
+              ok?: boolean;
+              error?: string;
+              totalTokens?: number;
+            };
+            const workflowId = String(ev.workflowId ?? "");
+            if (!workflowId) return;
+            if (kind === "started") {
+              upsertWorkflow(workflowId, () => ({
+                label: String(ev.label ?? ""),
+                agentCount: Number(ev.agentCount ?? 0),
+                agents: new Map(),
+                ok: null,
+                totalTokens: 0,
+              }));
+              return;
+            }
+            if (kind === "completed") {
+              upsertWorkflow(workflowId, (w) => {
+                if (!w) return w;
+                return { ...w, ok: ev.ok === true, totalTokens: Number(ev.totalTokens ?? 0) };
+              });
+              return;
+            }
+            const agentId = String(ev.agentId ?? "");
+            const agentState: WorkflowAgentState =
+              kind === "agent_started"
+                ? { label: String(ev.label ?? ""), status: "running" }
+                : ev.ok === true
+                  ? { label: String(ev.label ?? ""), status: "done" }
+                  : {
+                      label: String(ev.label ?? ""),
+                      status: "failed",
+                      error: String(ev.error ?? ""),
+                    };
+            upsertWorkflow(workflowId, (w) => {
+              if (!w) return w;
+              const agents = new Map(w.agents);
+              agents.set(agentId, agentState);
+              return { ...w, agents };
+            });
+          } catch {
+            /* malformed - ignore */
+          }
+        };
+      es.addEventListener("workflow_started", workflowEvent("started"));
+      es.addEventListener("workflow_agent_started", workflowEvent("agent_started"));
+      es.addEventListener("workflow_agent_completed", workflowEvent("agent_completed"));
+      es.addEventListener("workflow_completed", workflowEvent("completed"));
     },
     [
       clearRunRecap,
@@ -545,5 +629,6 @@ export function useConversation(
     transientTools,
     runTodos,
     runRecaps,
+    workflows,
   };
 }

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,14 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["**", "!**/bun.lock", "!**/drizzle", "!**/dist", "!**/.next"]
+    "includes": [
+      "**",
+      "!**/bun.lock",
+      "!**/drizzle",
+      "!**/dist",
+      "!**/.next",
+      "!skills/loop-workflow/workflow.js"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "@my-agent-team/adapter-omp-agent": "workspace:*",
         "@my-agent-team/adapter-pi-agent": "workspace:*",
         "@my-agent-team/agent-backend": "workspace:*",
+        "@my-agent-team/ai": "workspace:*",
         "@my-agent-team/api-contract": "workspace:*",
         "@my-agent-team/config": "workspace:*",
         "@my-agent-team/conversation": "workspace:*",

--- a/docs/superpowers/plans/2026-08-13-coding-agent-workflow.md
+++ b/docs/superpowers/plans/2026-08-13-coding-agent-workflow.md
@@ -1,0 +1,1040 @@
+# Coding Agent 动态工作流实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 coding-agent 增加进程内动态工作流能力(子代理扇出 + 脚本编排),并将 backend loop 改造为首个消费者。
+
+**Architecture:** 全进程内。workflow 执行器在 child 里创建独立子会话(同模型 + 文件工具、独立 store、空上下文),并发上限 8/总数 64;脚本经 `node:vm` 白名单沙箱求值;事件走现有 wire(RPC → backend SSE → 前端进度卡)。loop 状态载入脚本 meta,纯 reducer 校验写回。
+
+**Tech Stack:** Bun、TypeScript(ESM/NodeNext)、`node:vm`、bun:test、Next.js 15 App Router。
+
+**Spec:** `docs/superpowers/specs/2026-08-13-coding-agent-workflow-design.md`
+
+---
+
+## 文件地图
+
+| 文件 | 责任 |
+|---|---|
+| `apps/coding-agent/src/core/workflow-executor.ts`(新) | 子代理引擎:`runSubagent` + `runWorkflow` + 并发/总数上限 + 预算钩子 + 事件发射 |
+| `apps/coding-agent/src/core/workflow-tools.ts`(新) | 两个 PluginTool:`run_workflow`(Phase 1)、`workflow_run`(Phase 2) |
+| `apps/coding-agent/src/core/workflow-evaluator.ts`(新,Phase 2) | vm 沙箱:`agent`/`pipeline` 原语 + 60s 脚本预算 |
+| `apps/coding-agent/src/core/run-runtime.ts`(改) | 装配执行器 + 注册 workflow 工具 + 抽出共享的文件工具构造 |
+| `packages/agent/src/runtime/agent-event.ts`(改) | `CodingAgentLoopEvent` += 4 个 workflow 事件 |
+| `packages/agent-backend/src/event.ts`(改) | `CoreBackendEvent` += 4 个 workflow 事件 |
+| `packages/agent-backend/src/mapping.ts`(改) | `mapRunEvent` += 4 个 case |
+| `apps/web/src/hooks/useConversation.ts`(改) | workflow 状态 + 4 个 SSE 监听 |
+| `apps/web/src/components/ConversationCanvas.tsx`(改) | 进度卡渲染(与 TodoPanel 同处) |
+| `packages/loop/src/loop-reducer.ts`(改,Phase 3) | 导出 meta 写回校验器 |
+| `apps/backend/src/features/loop/loop-step.ts`(改,Phase 3) | generator run 用 workflow;meta 校验接线 |
+| `apps/backend/src/features/agent-run/execution.ts`(改,Phase 3) | run 输入带 workflow 预算(可选字段) |
+
+---
+
+# Phase 1:子代理原语
+
+## Task 1:工作流事件类型(child 内部 + 产品契约)
+
+**Files:**
+- Modify: `packages/agent/src/runtime/agent-event.ts`(union 尾部)
+- Modify: `packages/agent-backend/src/event.ts`(`CoreBackendEvent` union 尾部)
+
+- [ ] **Step 1:写失败测试**
+
+`packages/agent-backend/src/mapping.test.ts`(不存在则建,与 mapping.ts 同目录)追加:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { mapRunEvent } from "./mapping.js";
+
+describe("workflow event mapping", () => {
+  test("workflow lifecycle events map 1:1 to core events", () => {
+    expect(
+      mapRunEvent({ id: 1, type: "workflow_started", data: { workflowId: "wf1", label: "audit", agentCount: 12 } }),
+    ).toEqual({ type: "workflow_started", workflowId: "wf1", label: "audit", agentCount: 12 });
+    expect(
+      mapRunEvent({ id: 2, type: "workflow_agent_started", data: { workflowId: "wf1", agentId: "a1", label: "src/a.ts" } }),
+    ).toEqual({ type: "workflow_agent_started", workflowId: "wf1", agentId: "a1", label: "src/a.ts" });
+    expect(
+      mapRunEvent({
+        id: 3,
+        type: "workflow_agent_completed",
+        data: { workflowId: "wf1", agentId: "a1", label: "src/a.ts", ok: true },
+      }),
+    ).toEqual({ type: "workflow_agent_completed", workflowId: "wf1", agentId: "a1", label: "src/a.ts", ok: true });
+    expect(
+      mapRunEvent({
+        id: 4,
+        type: "workflow_completed",
+        data: { workflowId: "wf1", ok: false, agentCount: 12, totalTokens: 500 },
+      }),
+    ).toEqual({ type: "workflow_completed", workflowId: "wf1", ok: false, agentCount: 12, totalTokens: 500 });
+  });
+});
+```
+
+- [ ] **Step 2:运行确认失败**
+
+Run: `cd packages/agent-backend && bun test src/mapping.test.ts`
+Expected: FAIL(TS 编译错:`CodingAgentLoopEvent`/`BackendEvent` 缺 workflow 成员)
+
+- [ ] **Step 3:实现事件类型**
+
+`packages/agent/src/runtime/agent-event.ts` union 尾部(最后一个 `;` 前)加:
+
+```ts
+  | { type: "workflow_started"; workflowId: string; label: string; agentCount: number }
+  | { type: "workflow_agent_started"; workflowId: string; agentId: string; label: string }
+  | {
+      type: "workflow_agent_completed";
+      workflowId: string;
+      agentId: string;
+      label: string;
+      ok: boolean;
+      error?: string;
+      usage?: Readonly<Record<string, unknown>>;
+    }
+  | {
+      type: "workflow_completed";
+      workflowId: string;
+      ok: boolean;
+      agentCount: number;
+      totalTokens: number;
+    };
+```
+
+`packages/agent-backend/src/event.ts` `CoreBackendEvent` union 尾部加同构四行(与 child 1:1,字段名一致,`usage` 用 `Readonly<Record<string, unknown>>`)。
+
+`packages/agent-backend/src/mapping.ts` switch 尾部(默认分支前)加:
+
+```ts
+    case "workflow_started":
+      return {
+        type: "workflow_started",
+        workflowId: String(event.data.workflowId ?? ""),
+        label: String(event.data.label ?? ""),
+        agentCount: Number(event.data.agentCount ?? 0),
+      };
+    case "workflow_agent_started":
+      return {
+        type: "workflow_agent_started",
+        workflowId: String(event.data.workflowId ?? ""),
+        agentId: String(event.data.agentId ?? ""),
+        label: String(event.data.label ?? ""),
+      };
+    case "workflow_agent_completed": {
+      const usage = event.data.usage as Readonly<Record<string, unknown>> | undefined;
+      return {
+        type: "workflow_agent_completed",
+        workflowId: String(event.data.workflowId ?? ""),
+        agentId: String(event.data.agentId ?? ""),
+        label: String(event.data.label ?? ""),
+        ok: event.data.ok === true,
+        ...(typeof event.data.error === "string" ? { error: event.data.error } : {}),
+        ...(usage ? { usage } : {}),
+      };
+    }
+    case "workflow_completed":
+      return {
+        type: "workflow_completed",
+        workflowId: String(event.data.workflowId ?? ""),
+        ok: event.data.ok === true,
+        agentCount: Number(event.data.agentCount ?? 0),
+        totalTokens: Number(event.data.totalTokens ?? 0),
+      };
+```
+
+- [ ] **Step 4:运行确认通过**
+
+Run: `cd packages/agent-backend && bun test src/mapping.test.ts`
+Expected: PASS
+
+- [ ] **Step 5:Commit**
+
+```bash
+git add packages/agent/src/runtime/agent-event.ts packages/agent-backend/src/event.ts packages/agent-backend/src/mapping.ts packages/agent-backend/src/mapping.test.ts
+git commit -m "feat(agent): workflow lifecycle events in the wire contract"
+```
+
+## Task 2:workflow 执行器引擎
+
+**Files:**
+- Create: `apps/coding-agent/src/core/workflow-executor.ts`
+- Test: `apps/coding-agent/src/core/workflow-executor.test.ts`
+
+- [ ] **Step 1:写失败测试**
+
+`workflow-executor.test.ts`:
+
+```ts
+import { afterEach, describe, expect, test } from "bun:test";
+import { createEchoModelStream } from "./__fixtures__/echo-model.js"; // 见 Step 3 的 fixture
+import { createWorkflowExecutor } from "./workflow-executor.js";
+
+const events: unknown[] = [];
+const emit = (e: unknown) => events.push(e);
+
+function makeDeps() {
+  return {
+    makeSubagentStream: (prompt: string) =>
+      createEchoModelStream(`echo:${prompt}`), // 每个子代理 echo 自己的 prompt
+    summarize: async () => "[summary]",
+    contextBudget: { estimate: () => 0, limit: 100000, triggerRatio: 0.7 },
+    tools: [], // 空工具足够:echo 模型不调工具
+    maxConcurrent: 2,
+    maxTotal: 4,
+    emit,
+  };
+}
+
+describe("createWorkflowExecutor", () => {
+  afterEach(() => events.length = 0);
+
+  test("runWorkflow fans out, caps concurrency, and aggregates", async () => {
+    const exec = createWorkflowExecutor(makeDeps() as never);
+    const started: string[] = [];
+    // 记录实际并发:包装 makeSubagentStream 太绕,改由 executor 的 agent 事件数断言
+    const result = await exec.runWorkflow({
+      workflowId: "wf1",
+      label: "audit",
+      items: [
+        { prompt: "one", label: "a" },
+        { prompt: "two", label: "b" },
+        { prompt: "three", label: "c" },
+      ],
+    });
+    expect(result.items.map((i) => i.text)).toEqual(["echo:one", "echo:two", "echo:three"]);
+    expect(events.filter((e) => (e as { type: string }).type === "workflow_agent_started")).toHaveLength(3);
+    expect(events.filter((e) => (e as { type: string }).type === "workflow_agent_completed")).toHaveLength(3);
+    const done = events.find((e) => (e as { type: string }).type === "workflow_completed") as { ok: boolean };
+    expect(done.ok).toBe(true);
+  });
+
+  test("the total cap rejects excess agents with a clear error", async () => {
+    const exec = createWorkflowExecutor(makeDeps() as never);
+    await expect(
+      exec.runWorkflow({
+        workflowId: "wf2",
+        label: "big",
+        items: Array.from({ length: 5 }, (_, i) => ({ prompt: `p${i}` })),
+      }),
+    ).rejects.toThrow(/exceeds the 4-agent cap/);
+  });
+
+  test("a budget gate can refuse new spawns", async () => {
+    let budget = 2;
+    const exec = createWorkflowExecutor({
+      ...makeDeps(),
+      budgetGate: () => (--budget >= 0 ? { allowed: true } : { allowed: false, reason: "budget exhausted" }),
+    } as never);
+    await expect(
+      exec.runWorkflow({
+        workflowId: "wf3",
+        label: "gated",
+        items: [1, 2, 3].map((i) => ({ prompt: `p${i}` })),
+      }),
+    ).rejects.toThrow(/budget exhausted/);
+  });
+
+  test("schema output is parsed from the final text", async () => {
+    const exec = createWorkflowExecutor(makeDeps() as never);
+    const result = await exec.runSubagent({
+      workflowId: "wf4",
+      agentId: "a1",
+      prompt: "return json",
+      label: "x",
+      schema: { type: "object" },
+    });
+    expect(result.output).toEqual({ ok: true }); // echo fixture 返回 JSON 文本
+  });
+});
+```
+
+- [ ] **Step 2:运行确认失败**
+
+Run: `cd apps/coding-agent && bun test src/core/workflow-executor.test.ts`
+Expected: FAIL(module not found)
+
+- [ ] **Step 3:写 echo fixture + 实现**
+
+`apps/coding-agent/src/core/__fixtures__/echo-model.ts`:
+
+```ts
+import type { AIMessageChunk } from "@my-agent-team/message";
+
+/** Deterministic scripted model stream: yields one assistant text chunk
+ *  then ends. The text is JSON for schema tests when the prompt asks. */
+export function createEchoModelStream(text: string): (() => AsyncIterable<AIMessageChunk>) {
+  return async function* () {
+    yield { delta: { type: "text", text } } as AIMessageChunk;
+  };
+}
+```
+
+`workflow-executor.ts`:
+
+```ts
+import { randomUUID } from "node:crypto";
+import type { AIMessageChunk, Message } from "@my-agent-team/message";
+import type { ContextBudget, ContextSummarizer, PluginTool } from "@my-agent-team/agent";
+
+export interface WorkflowAgentSpec {
+  readonly prompt: string;
+  readonly label?: string;
+  readonly schema?: Readonly<Record<string, unknown>>;
+}
+
+export interface WorkflowAgentResult {
+  readonly label: string;
+  readonly text: string;
+  readonly output?: unknown;
+  readonly ok: boolean;
+  readonly error?: string;
+  readonly usage?: Readonly<Record<string, unknown>>;
+}
+
+export interface WorkflowExecutorOptions {
+  /** Build the subagent model stream (same model + reasoning as the run). */
+  readonly makeSubagentStream: (sessionId: string) => (() => AsyncIterable<AIMessageChunk>);
+  readonly summarize: ContextSummarizer;
+  readonly contextBudget: ContextBudget;
+  /** File tools only (no workflow/product tools — recursion + clobber guards). */
+  readonly tools: readonly PluginTool[];
+  readonly maxConcurrent: number;
+  readonly maxTotal: number;
+  readonly emit: (event: unknown) => void;
+  /** Optional product budget gate: consulted BEFORE each spawn. */
+  readonly budgetGate?: () => { allowed: boolean; reason?: string };
+}
+
+export interface WorkflowRunResult {
+  readonly items: readonly WorkflowAgentResult[];
+  readonly totalTokens: number;
+  readonly ok: boolean;
+}
+
+export interface WorkflowExecutor {
+  runSubagent(input: { workflowId: string; agentId: string } & WorkflowAgentSpec): Promise<WorkflowAgentResult>;
+  runWorkflow(input: { workflowId: string; label: string; items: readonly WorkflowAgentSpec[] }): Promise<WorkflowRunResult>;
+}
+
+export function createWorkflowExecutor(opts: WorkflowExecutorOptions): WorkflowExecutor {
+  let totalSpawned = 0;
+  const sem = { current: 0, max: opts.maxConcurrent, waiters: [] as Array<() => void> };
+
+  async function acquire(): Promise<void> {
+    if (sem.current < sem.max) {
+      sem.current++;
+      return;
+    }
+    await new Promise<void>((resolve) => sem.waiters.push(resolve));
+  }
+  function release(): void {
+    const next = sem.waiters.shift();
+    if (next) next();
+    else sem.current--;
+  }
+
+  function gate(): void {
+    if (totalSpawned >= opts.maxTotal) {
+      throw new Error(`workflow exceeds the ${opts.maxTotal}-agent cap`);
+    }
+    if (opts.budgetGate) {
+      const decision = opts.budgetGate();
+      if (!decision.allowed) throw new Error(decision.reason ?? "workflow budget exhausted");
+    }
+    totalSpawned++;
+  }
+
+  async function runSubagent(
+    input: { workflowId: string; agentId: string } & WorkflowAgentSpec,
+  ): Promise<WorkflowAgentResult> {
+    await acquire();
+    gate();
+    const sessionId = `wf:${input.workflowId}:${input.agentId}`;
+    opts.emit({ type: "workflow_agent_started", workflowId: input.workflowId, agentId: input.agentId, label: input.label ?? input.agentId });
+    try {
+      const { createCodingAgentSession } = await import("@my-agent-team/agent");
+      const { createInMemorySessionStore } = await import("@my-agent-team/agent");
+      const store = createInMemorySessionStore();
+      const session = createCodingAgentSession({
+        sessionId,
+        store,
+        plugins: [],
+        maxSteps: 8,
+        maxForceContinues: 2,
+        modelStream: opts.makeSubagentStream(sessionId),
+        summarize: opts.summarize,
+        contextBudget: opts.contextBudget,
+      });
+      const result = await session.startLoop({
+        input: {
+          inputId: input.agentId,
+          message: { role: "user" as const, text: input.prompt },
+        },
+        run: {
+          runId: sessionId,
+          model: { providerId: "echo", modelId: "echo" },
+          configRevision: 0,
+        },
+        metadata: { conversationId: "", agentMemberId: "", branchId: "" },
+      } as never);
+      void store.close().catch(() => {});
+      const text = (result.messages?.at(-1)?.text ?? "").trim();
+      let output: unknown;
+      let parseError: string | undefined;
+      if (input.schema && text) {
+        try {
+          output = JSON.parse(text);
+        } catch {
+          parseError = `schema output is not valid JSON: ${text.slice(0, 120)}`;
+        }
+      }
+      const agentResult: WorkflowAgentResult = {
+        label: input.label ?? input.agentId,
+        text,
+        ok: result.status === "completed" && !parseError,
+        ...(output !== undefined ? { output } : {}),
+        ...(parseError ? { error: parseError } : {}),
+        ...(result.usage ? { usage: result.usage as Readonly<Record<string, unknown>> } : {}),
+      };
+      opts.emit({
+        type: "workflow_agent_completed",
+        workflowId: input.workflowId,
+        agentId: input.agentId,
+        label: agentResult.label,
+        ok: agentResult.ok,
+        ...(agentResult.error ? { error: agentResult.error } : {}),
+        ...(agentResult.usage ? { usage: agentResult.usage } : {}),
+      });
+      return agentResult;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      opts.emit({
+        type: "workflow_agent_completed",
+        workflowId: input.workflowId,
+        agentId: input.agentId,
+        label: input.label ?? input.agentId,
+        ok: false,
+        error: message,
+      });
+      return { label: input.label ?? input.agentId, text: "", ok: false, error: message };
+    } finally {
+      release();
+    }
+  }
+
+  async function runWorkflow(input: {
+    workflowId: string;
+    label: string;
+    items: readonly WorkflowAgentSpec[];
+  }): Promise<WorkflowRunResult> {
+    opts.emit({ type: "workflow_started", workflowId: input.workflowId, label: input.label, agentCount: input.items.length });
+    const results = await Promise.all(
+      input.items.map((item, i) =>
+        runSubagent({ workflowId: input.workflowId, agentId: `a${i}`, ...item }),
+      ),
+    );
+    const totalTokens = results.reduce(
+      (acc, r) => acc + Number((r.usage as { totalTokens?: number } | undefined)?.totalTokens ?? 0),
+      0,
+    );
+    const ok = results.every((r) => r.ok);
+    opts.emit({
+      type: "workflow_completed",
+      workflowId: input.workflowId,
+      ok,
+      agentCount: input.items.length,
+      totalTokens,
+    });
+    return { items: results, totalTokens, ok };
+  }
+
+  return { runSubagent, runWorkflow };
+}
+```
+
+> 注意:`startLoop` 的类型对子代理并不精确(工具集不同)。若 TS 报 `CodingLoopInput` 缺字段,按最小快照补 `systemPrompt: null` / `permissionMode: null` / `skillRoots: null`——以 tsc 报错为准补齐,不伪造语义。
+
+- [ ] **Step 4:运行确认通过**
+
+Run: `cd apps/coding-agent && bun test src/core/workflow-executor.test.ts`
+Expected: PASS(4 tests)
+
+- [ ] **Step 5:Commit**
+
+```bash
+git add apps/coding-agent/src/core/workflow-executor.ts apps/coding-agent/src/core/workflow-executor.test.ts apps/coding-agent/src/core/__fixtures__/echo-model.ts
+git commit -m "feat(coding-agent): in-process workflow executor with caps and budget gate"
+```
+
+## Task 3:run_workflow 工具 + 装配进 run-runtime
+
+**Files:**
+- Create: `apps/coding-agent/src/core/workflow-tools.ts`
+- Modify: `apps/coding-agent/src/core/run-runtime.ts`(工具构造抽出 + 执行器装配 + 工具注册)
+
+- [ ] **Step 1:写失败测试**
+
+`apps/coding-agent/src/core/workflow-tools.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { createWorkflowTools } from "./workflow-tools.js";
+
+describe("createWorkflowTools", () => {
+  test("run_workflow exposes items + concurrency and executes the executor", async () => {
+    const calls: unknown[] = [];
+    const tools = createWorkflowTools({
+      runWorkflow: async (input) => {
+        calls.push(input);
+        return { items: [], totalTokens: 0, ok: true };
+      },
+      runScript: async () => {
+        throw new Error("not in phase 1");
+      },
+    });
+    const tool = tools.find((t) => t.name === "run_workflow");
+    expect(tool).toBeDefined();
+    expect(tool!.inputSchema?.type).toBe("object");
+    const result = await tool!.execute({ items: [{ prompt: "hi" }] }, undefined, { callId: "c1" });
+    expect(result).toEqual({ items: [], totalTokens: 0, ok: true });
+    expect(calls).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2:运行确认失败** → `cd apps/coding-agent && bun test src/core/workflow-tools.test.ts`,Expected: FAIL
+
+- [ ] **Step 3:实现**
+
+`workflow-tools.ts`:
+
+```ts
+import type { PluginTool } from "@my-agent-team/agent";
+import type { WorkflowRunResult, WorkflowAgentSpec } from "./workflow-executor.js";
+
+export interface WorkflowToolDeps {
+  readonly runWorkflow: (input: {
+    workflowId: string;
+    label: string;
+    items: readonly WorkflowAgentSpec[];
+  }) => Promise<WorkflowRunResult>;
+  /** Phase 2 填充;Phase 1 传抛错桩,run_workflow 是唯一工具。 */
+  readonly runScript: (input: { script: string; args?: unknown }) => Promise<WorkflowRunResult>;
+}
+
+export function createWorkflowTools(deps: WorkflowToolDeps): readonly PluginTool[] {
+  const runWorkflow: PluginTool = {
+    name: "run_workflow",
+    description:
+      "Fan out independent subagent tasks in parallel and aggregate their results. Each item gets its own isolated agent session (same model, file tools). Use for audits, migrations, and multi-source research. Items: [{prompt, schema?, label?}]. Returns per-item text and schema-parsed output.",
+    executionMode: "serial",
+    inputSchema: {
+      type: "object",
+      properties: {
+        label: { type: "string" },
+        concurrency: { type: "number", maximum: 8 },
+        items: {
+          type: "array",
+          maxItems: 64,
+          items: {
+            type: "object",
+            properties: {
+              prompt: { type: "string" },
+              label: { type: "string" },
+              schema: { type: "object" },
+            },
+            required: ["prompt"],
+          },
+        },
+      },
+      required: ["items"],
+    },
+    async execute(args) {
+      const items = Array.isArray(args.items) ? args.items : [];
+      const workflowId = `wf-${Date.now().toString(36)}`;
+      const result = await deps.runWorkflow({
+        workflowId,
+        label: typeof args.label === "string" ? args.label : "workflow",
+        items: items.map((raw) => {
+          const item = raw as Record<string, unknown>;
+          return {
+            prompt: String(item.prompt ?? ""),
+            ...(typeof item.label === "string" ? { label: item.label } : {}),
+            ...(item.schema && typeof item.schema === "object" ? { schema: item.schema } : {}),
+          };
+        }),
+      });
+      return { items: result.items, totalTokens: result.totalTokens, ok: result.ok };
+    },
+  };
+  return [runWorkflow];
+}
+```
+
+`run-runtime.ts` 装配(把 `assembleRunRuntime` 里 `const tools: PluginTool[] = [...]` 的构造抽成 `buildFileTools(deps)` 局部函数,再在 `plugins` 定义前加):
+
+```ts
+  const executor = createWorkflowExecutor({
+    makeSubagentStream: (sessionId) => async function* () {
+      const run = activeRun;
+      if (!run) throw new Error("no active run");
+      const catalog = await deps.modelRuntime.getCatalog();
+      const model = catalog.models.find(
+        (m) => `${m.providerId}/${m.modelId}` === resolveModelAlias(run.model.modelId),
+      );
+      if (!model) throw new Error(`model not found: ${run.model.modelId}`);
+      const timeoutSignal = AbortSignal.timeout(modelTimeoutMs);
+      const stream = deps.modelRuntime.stream(model.providerId, model.modelId, messagesOf(sessionId), {
+        signal: timeoutSignal,
+        cacheControl: true,
+      });
+      yield* stream;
+    },
+    summarize,
+    contextBudget,
+    tools: fileTools,
+    maxConcurrent: 8,
+    maxTotal: 64,
+    emit: (event) => sessionEmit?.(event as never),
+  });
+  const workflowTools = createWorkflowTools({
+    runWorkflow: (input) => executor.runWorkflow(input),
+    runScript: async () => {
+      throw new Error("workflow_run arrives in phase 2");
+    },
+  });
+```
+
+> `messagesOf(sessionId)` = 子代理流与主 modelStream 同构(直接调 `deps.modelRuntime.stream`),不需要 `activeRun` 外的信息——子代理消息由 session 自己喂;实现时把主 modelStream 的 reasoning 提取逻辑复用成一个共享闭包 `streamFor(messages, signal)`。保持行为不变,不复制 reasoning 分支。
+
+`tools` 数组末尾加 `...workflowTools`(在 `nativeToolsPlugin` 之前定义,注意 `fileTools` 变量持有核心工具数组,`nativeToolsPlugin = { name: "native-tools", tools: fileTools }`)。
+
+- [ ] **Step 4:运行确认通过**
+
+Run: `cd apps/coding-agent && bun test src/core/` + `cd /root/my-agent-team && bun run typecheck`
+Expected: PASS / 42 tasks
+
+- [ ] **Step 5:Commit**
+
+```bash
+git add apps/coding-agent/src/core/
+git commit -m "feat(coding-agent): run_workflow tool wired into the run runtime"
+```
+
+## Task 4:前端进度卡
+
+**Files:**
+- Modify: `apps/web/src/hooks/useConversation.ts`
+- Modify: `apps/web/src/components/ConversationCanvas.tsx`(进度卡组件,与 TodoPanel 同文件区域)
+
+- [ ] **Step 1:状态 + 监听**
+
+`useConversation.ts`(与 `setRunTodosState` 同层)加:
+
+```ts
+export interface WorkflowAgentState {
+  readonly label: string;
+  readonly status: "running" | "done" | "failed";
+  readonly error?: string;
+}
+export interface WorkflowRunState {
+  readonly label: string;
+  readonly agentCount: number;
+  readonly agents: ReadonlyMap<string, WorkflowAgentState>;
+  readonly ok: boolean | null;
+  readonly totalTokens: number;
+}
+
+const [workflows, setWorkflows] = useState<ReadonlyMap<string, WorkflowRunState>>(new Map());
+const upsertWorkflow = useCallback((workflowId: string, patch: (w: WorkflowRunState | undefined) => WorkflowRunState | undefined) => {
+  setWorkflows((prev) => {
+    const next = new Map(prev);
+    const updated = patch(prev.get(workflowId));
+    if (updated) next.set(workflowId, updated);
+    else next.delete(workflowId);
+    return next;
+  });
+}, []);
+```
+
+SSE 监听(与 native_tool 监听同块)加:
+
+```ts
+      const onWorkflow = (e: Event) => {
+        try {
+          const ev = JSON.parse((e as MessageEvent).data) as Record<string, unknown>;
+          const workflowId = String(ev.workflowId ?? "");
+          switch ((e.target as { type?: string })?.type) {
+            case "workflow_started":
+              upsertWorkflow(workflowId, () => ({
+                label: String(ev.label ?? ""),
+                agentCount: Number(ev.agentCount ?? 0),
+                agents: new Map(),
+                ok: null,
+                totalTokens: 0,
+              }));
+              break;
+            case "workflow_agent_started":
+              upsertWorkflow(workflowId, (w) =>
+                w
+                  ? { ...w, agents: new Map(w.agents).set(String(ev.agentId ?? ""), { label: String(ev.label ?? ""), status: "running" }) }
+                  : w,
+              );
+              break;
+            case "workflow_agent_completed":
+              upsertWorkflow(workflowId, (w) =>
+                w
+                  ? {
+                      ...w,
+                      agents: new Map(w.agents).set(String(ev.agentId ?? ""), {
+                        label: String(ev.label ?? ""),
+                        status: ev.ok === true ? "done" : "failed",
+                        ...(typeof ev.error === "string" ? { error: ev.error } : {}),
+                      }),
+                    }
+                  : w,
+              );
+              break;
+            case "workflow_completed":
+              upsertWorkflow(workflowId, (w) =>
+                w ? { ...w, ok: ev.ok === true, totalTokens: Number(ev.totalTokens ?? 0) } : w,
+              );
+              break;
+          }
+        } catch {
+          /* malformed - ignore */
+        }
+      };
+      es.addEventListener("workflow_started", onWorkflow);
+      es.addEventListener("workflow_agent_started", onWorkflow);
+      es.addEventListener("workflow_agent_completed", onWorkflow);
+      es.addEventListener("workflow_completed", onWorkflow);
+```
+
+- [ ] **Step 2:进度卡组件**
+
+`ConversationCanvas.tsx`(TodoPanel 旁)加 `WorkflowPanel`,接收 `workflows` + `runId` 过滤(仅显示当前 run 的 workflow——用 `workflowId` 前缀 `wf-<ts>`,按时间保留最新;v1 显示全部进行中):
+
+```tsx
+function WorkflowPanel({ workflows }: { workflows: ReadonlyMap<string, WorkflowRunState> }) {
+  const running = [...workflows.entries()].filter(([, w]) => w.ok === null);
+  if (running.length === 0) return null;
+  return (
+    <div className="rounded-lg border p-3 text-sm">
+      {running.map(([id, w]) => {
+        const done = [...w.agents.values()].filter((a) => a.status !== "running").length;
+        return (
+          <div key={id}>
+            <div className="font-medium">
+              {w.label} · {done}/{w.agentCount} agents
+            </div>
+            <ul>
+              {[...w.agents.entries()].map(([agentId, a]) => (
+                <li key={agentId} className={a.status === "failed" ? "text-red-600" : ""}>
+                  {a.status === "running" ? "⏳" : a.status === "done" ? "✓" : "✗"} {a.label}
+                  {a.error ? ` — ${a.error.slice(0, 80)}` : ""}
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+> 样式以现有 TodoPanel 的 tailwind 类为参照,保持一致(space/2 格式由 biome 处理)。
+
+- [ ] **Step 3:验证**
+
+Run: `cd /root/my-agent-team && bun run typecheck && bun run lint`
+Expected: 42/42 + 23/23
+
+- [ ] **Step 4:Commit**
+
+```bash
+git add apps/web/src/
+git commit -m "feat(web): workflow progress card from SSE events"
+```
+
+## Task 5:Phase 1 端到端验收
+
+- [ ] **Step 1:集成测试**——`apps/coding-agent/src/core/create-runtime.test.ts` 补一个 case:用 scripted 模型(首轮发 `run_workflow` 工具调用,items=2 个 echo prompt)→ 断言 outcome 完成 + 事件流含 4 类 workflow 事件 + 工具结果含 2 个 item text。参照现有 create-runtime.test 的 harness 写。
+- [ ] **Step 2:全量门禁**
+
+Run: `cd /root/my-agent-team && bun run typecheck && bun run lint && bun run test`
+Expected: 全绿
+
+- [ ] **Step 3:Commit + 推分支**
+
+```bash
+git add -A && git commit -m "test(coding-agent): phase 1 workflow end-to-end" && git push -u origin feat/coding-agent-workflow
+```
+
+---
+
+# Phase 2:脚本求值器
+
+## Task 6:vm 沙箱求值器
+
+**Files:**
+- Create: `apps/coding-agent/src/core/workflow-evaluator.ts`
+- Test: `apps/coding-agent/src/core/workflow-evaluator.test.ts`
+
+- [ ] **Step 1:失败测试**
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { evaluateWorkflowScript } from "./workflow-evaluator.js";
+
+const primitives = {
+  agent: async (prompt: string) => ({ text: `echo:${prompt}`, output: undefined, ok: true, label: "" }),
+  pipeline: async (items: readonly unknown[], fn: (item: unknown) => Promise<unknown>) =>
+    Promise.all(items.map(fn)),
+};
+
+describe("evaluateWorkflowScript", () => {
+  test("runs top-level await scripts with agent + pipeline", async () => {
+    const result = await evaluateWorkflowScript({
+      script: `const found = await agent("find"); const all = await pipeline(found.text.split(","), (x) => agent(x)); return all.length;`,
+      args: undefined,
+      primitives: primitives as never,
+    });
+    expect(result.value).toBe(1);
+  });
+
+  test("args are passed as a global", async () => {
+    const result = await evaluateWorkflowScript({
+      script: `return args.count * 2;`,
+      args: { count: 21 },
+      primitives: primitives as never,
+    });
+    expect(result.value).toBe(42);
+  });
+
+  test("fs/process/require are absent", async () => {
+    await expect(
+      evaluateWorkflowScript({
+        script: `return typeof process;`,
+        args: undefined,
+        primitives: primitives as never,
+      }),
+    ).rejects.toThrow(/process is not defined/);
+  });
+
+  test("the 60s budget aborts a stalled script", async () => {
+    await expect(
+      evaluateWorkflowScript({
+        script: `while (true) {}`,
+        args: undefined,
+        primitives: primitives as never,
+        timeoutMs: 50,
+      }),
+    ).rejects.toThrow(/timed out/);
+  });
+});
+```
+
+- [ ] **Step 2:失败确认** → `cd apps/coding-agent && bun test src/core/workflow-evaluator.test.ts`
+
+- [ ] **Step 3:实现**
+
+```ts
+import vm from "node:vm";
+
+export interface WorkflowPrimitives {
+  readonly agent: (prompt: string, opts?: { schema?: unknown; label?: string }) => Promise<unknown>;
+  readonly pipeline: (
+    items: readonly unknown[],
+    fn: (item: unknown) => Promise<unknown>,
+    opts?: { concurrency?: number },
+  ) => Promise<readonly unknown[]>;
+}
+
+export interface EvaluateResult {
+  readonly value: unknown;
+}
+
+/** Sandboxed script evaluation: ONLY agent/pipeline/args are injected.
+ *  require/process/fs/fetch do not exist inside the script. The vm timeout
+ *  covers synchronous infinite loops; the caller races the returned promise
+ *  against the script budget for async stalls. */
+export async function evaluateWorkflowScript(input: {
+  readonly script: string;
+  readonly args?: unknown;
+  readonly primitives: WorkflowPrimitives;
+  readonly timeoutMs?: number;
+}): Promise<EvaluateResult> {
+  const timeoutMs = input.timeoutMs ?? 60_000;
+  const { agent, pipeline } = input.primitives;
+  const context = vm.createContext({ agent, pipeline, args: input.args }, { name: "workflow-script" });
+  const wrapped = `(async () => { ${input.script} })()`;
+  const promise = vm.runInContext(wrapped, context, { timeout: timeoutMs }) as Promise<unknown>;
+  const timer = new Promise<never>((_, reject) => {
+    const id = setTimeout(() => reject(new Error("workflow script timed out")), timeoutMs);
+    promise.finally(() => clearTimeout(id)).catch(() => {});
+  });
+  const value = await Promise.race([promise, timer]);
+  return { value };
+}
+```
+
+- [ ] **Step 4:通过确认** → `cd apps/coding-agent && bun test src/core/workflow-evaluator.test.ts`
+
+- [ ] **Step 5:Commit**
+
+```bash
+git add apps/coding-agent/src/core/workflow-evaluator.ts apps/coding-agent/src/core/workflow-evaluator.test.ts
+git commit -m "feat(coding-agent): sandboxed workflow script evaluator"
+```
+
+## Task 7:workflow_run 工具 + 脚本落盘
+
+**Files:**
+- Modify: `apps/coding-agent/src/core/workflow-tools.ts`(加 `workflow_run` 工具)
+- Modify: `apps/coding-agent/src/core/run-runtime.ts`(`runScript` 桩 → 真实实现)
+
+- [ ] **Step 1:`workflow-tools.ts` 加工具**
+
+`createWorkflowTools` 的返回数组加(需要 `deps.runScript` + 一个新 deps 字段 `writeScript: (name: string, content: string) => void`):
+
+```ts
+  const runScript: PluginTool = {
+    name: "workflow_run",
+    description:
+      "Run an orchestration script (top-level-await JS) that fans out subagents via agent() and pipeline(). Scripts have NO fs/network access - agents do the work. Write scripts to .workflows/<name>.js for reuse.",
+    executionMode: "serial",
+    inputSchema: {
+      type: "object",
+      properties: {
+        script: { type: "string", maxLength: 32768 },
+        name: { type: "string" },
+        args: { type: "object" },
+      },
+      required: ["script"],
+    },
+    async execute(args) {
+      const script = typeof args.script === "string" ? args.script : "";
+      if (typeof args.name === "string" && args.name.length > 0) {
+        deps.writeScript(args.name, script);
+      }
+      const result = await deps.runScript({ script, args: args.args });
+      return { ...result, scriptSaved: typeof args.name === "string" };
+    },
+  };
+  return [runWorkflow, runScript];
+```
+
+- [ ] **Step 2:`run-runtime.ts` 接真实实现**
+
+```ts
+  const workflowTools = createWorkflowTools({
+    runWorkflow: (input) => executor.runWorkflow(input),
+    runScript: async ({ script, args }) => {
+      const result = await evaluateWorkflowScript({
+        script,
+        args,
+        primitives: {
+          agent: (prompt, opts) =>
+            executor.runSubagent({
+              workflowId: currentWorkflowId(),
+              agentId: randomUUID(),
+              prompt,
+              ...(opts?.schema ? { schema: opts.schema as never } : {}),
+              ...(opts?.label ? { label: opts.label } : {}),
+            }),
+          pipeline: async (items, fn) => {
+            const runs = items.map((item) => fn(item));
+            return Promise.all(runs);
+          },
+        },
+      });
+      return { items: [], totalTokens: 0, ok: true, scriptValue: result.value };
+    },
+    writeScript: (name, content) => {
+      const dir = join(deps.workspaceRoot, ".workflows");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, `${name}.js`), content);
+    },
+  });
+```
+
+> `currentWorkflowId()` = 每 run 一个稳定 id(workflow_run 调用时生成,`agent()` 内共享);脚本结果的 `value` 进工具结果。pipeline 的并发限制沿用执行器信号量(Phase 1 的信号量已内置,`Promise.all` 直通)。
+
+- [ ] **Step 3:验证** → `cd /root/my-agent-team && bun run typecheck && bun run lint && bun run test`
+- [ ] **Step 4:Commit**
+
+```bash
+git add apps/coding-agent/src/core/
+git commit -m "feat(coding-agent): workflow_run tool with sandboxed scripts and .workflows persistence"
+```
+
+## Task 8:Phase 2 验收 + push
+
+- [ ] **Step 1:** `create-runtime.test.ts` 补 scripted 模型用例:模型首轮写脚本到 `.workflows/audit.js` + 调 `workflow_run` → 断言文件落盘 + 结果 + 事件。临时目录 workspace(参照现有测试的 mkdtemp 模式)。
+- [ ] **Step 2:** 全量门禁 `bun run typecheck && bun run lint && bun run test`
+- [ ] **Step 3:** commit + push
+
+---
+
+# Phase 3:Loop 消费者
+
+## Task 9:reducer 导出 meta 写回校验器
+
+**Files:**
+- Modify: `packages/loop/src/loop-reducer.ts`
+- Modify: `packages/loop/src/index.ts`
+- Test: `packages/loop/src/loop-reducer.test.ts`
+
+- [ ] **Step 1:失败测试**
+
+```ts
+import { validateLoopMetaPatch } from "./loop-reducer.js";
+// 合法:item 状态按 step 顺序前进
+const valid = validateLoopMetaPatch(
+  { items: [{ id: "i1", step: "generated", content: "" }] },
+  { items: [{ id: "i1", step: "evaluated", content: "x" }] },
+);
+expect(valid.ok).toBe(true);
+// 非法:回跳 step / 未知 item / 非法状态名
+expect(validateLoopMetaPatch({ items: [] }, { items: [{ id: "i9", step: "generated" }] }).ok).toBe(false);
+```
+
+- [ ] **Step 2:实现**——`validateLoopMetaPatch(before, after): { ok: true } | { ok: false; reason: string }`:
+  - `after` 的 item id 集合 ⊆ `before` 的 id 集合 ∪ 本次可新建的 id(生成阶段引入的新 item 必须有 `generated` 初始 step);
+  - 每个 item 的 step 只能按 7 步顺序前进或停留,不能回退;
+  - 状态名必须在 7 步枚举内;`verdict` 值必须在枚举内。
+  - 纯函数,无 I/O;复用现有 `loopReducer` 的 step 常量。
+- [ ] **Step 3:通过 + commit** → `bun test packages/loop && git commit -m "feat(loop): meta writeback validator from the pure reducer invariants"`
+
+## Task 10:loop workflow 脚本模板(bundled)
+
+**Files:**
+- Create: `skills/loop-workflow/SKILL.md` + `skills/loop-workflow/workflow.js`(模板脚本:meta 块 + 生成/评估/重试 body)
+
+- [ ] **Step 1:** 模板脚本(body 用 `agent`/`pipeline` 写生成→评估→条件重试循环;meta 块 = `export const meta = { items: [...], budgetSpent: 0 }`,注释标明 meta 由产品校验器接管、模型只能追加合法转移)。
+- [ ] **Step 2:** SKILL.md 描述 loop 语义 + 脚本用法 + 约束(meta 写回规则、预算上限)。
+- [ ] **Step 3:commit** → `feat(loop): bundled loop workflow template`
+
+## Task 11:loop-step 接线(meta 校验 + workflow 化生成)
+
+**Files:**
+- Modify: `apps/backend/src/features/loop/loop-step.ts`
+- Modify: `apps/backend/src/features/agent-run/execution.ts`(可选 `run.workflowBudgetTokens` 字段,预算钩子用)
+
+- [ ] **Step 1:run 输入加可选预算字段**——`BackendRunInput` 的 run snapshot 加 `workflowBudgetTokens?: number`;backend loop-step 派发时把 loop 剩余预算写入;child 的 `assembleRunRuntime` 读 `input.run.workflowBudgetTokens` → `executor.budgetGate`(累计 spawn 估算 tokens 耗尽即拒)。
+- [ ] **Step 2:loop-step 的 generator run 改 workflow 化**——generator 的 systemPrompt 指向 loop-workflow 模板;run 完成后读 workspace `.workflows/loop.js` 的 meta → `validateLoopMetaPatch(beforeMeta, afterMeta)` → 通过则写回 STATE.md(现有写回路径不变,只换数据来源),不通过则该 step 判 failed + 保留 before。
+- [ ] **Step 3:evaluator 独立 run 删除**——生成/评估/重试收编进脚本后,evaluator dispatch 分支删除,verdict 从 meta 读。
+- [ ] **Step 4:测试迁移**——`loop-step.test.ts` 的 mockSessionFactory 改为回写 `.workflows/loop.js`(meta 合法/非法两个 fixture 分别断言通过/拒绝);`scheduler.test.ts` fixture 同步。
+- [ ] **Step 5:全量门禁 + commit**
+
+---
+
+## Self-Review 记录
+
+1. **Spec 覆盖**:§3 原语→Task 2/3;§3.3 边界(工具白名单/无插件/abort)→executor 实现 + Task 3 装配;§4 事件→Task 1 + Task 4;§5 求值器→Task 6/7;§6 loop→Task 9/10/11;§7 前端→Task 4;§8 实施顺序→三 Phase 对应。
+2. **占位符扫描**:无 TBD/TODO;子代理 `startLoop` 的 run 快照最小字段以 tsc 为准补齐(已注明)。
+3. **类型一致性**:`WorkflowRunResult`/`WorkflowAgentSpec`/事件字段名三处一致(`workflowId`/`agentId`/`label`/`ok`/`totalTokens`);`runWorkflow` deps 签名 Task 3 与 Task 7 一致。

--- a/docs/superpowers/specs/2026-08-13-coding-agent-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-13-coding-agent-workflow-design.md
@@ -1,0 +1,152 @@
+# Coding Agent 动态工作流(workflow)设计
+
+- 日期:2026-08-13
+- 分支:`feat/coding-agent-workflow`
+- 状态:设计已获批(问卷 + 四段设计 + loop 消费者方向)
+
+## 1. 背景与目标
+
+参考 Claude Code 的 dynamic workflow:模型把"大规模编排"写成脚本(或直接调用编排原语),运行时执行,会话/run 保持响应。目标:
+
+1. **第一步(子代理原语)**:coding-agent 获得进程内大规模并行子代理能力——模型用工具扇出 N 个子代理并发执行、聚合结果。
+2. **第二步(脚本运行时)**:模型把编排写成可读、可改、可重跑的 JS 脚本(`agent()` / `pipeline()` 原语),沙箱求值。
+3. **loop 改造(首个消费者)**:backend 的 loop feature 重构为"bundled workflow + 产品薄控制面"——持久状态载入脚本 meta,纯 reducer 降级为 meta 写回校验器。
+
+## 2. 已定决策(问卷结论)
+
+| 决策点 | 结论 |
+|---|---|
+| 范围 | 两步走(先子代理原语,再脚本运行时) |
+| 子代理能力 | 同模型 + 核心文件工具,共享 workspace(两个边界例外见 §3) |
+| 触发方式 | 分阶段:先模型工具调用,后命令入口 |
+| 进度呈现 | 事件上产品线(wire → backend SSE → 前端) |
+| 持久化 | 脚本存 workspace `.workflows/`;run 状态不恢复 |
+| 实现路径 | 方案 1:全进程内(child 内子代理 + 沙箱求值器) |
+| loop 分层 | meta 载状态 + reducer 校验写回 + 产品薄控制面 |
+
+## 3. 子代理运行时(第一步)
+
+### 3.1 原语
+
+```ts
+runSubagent({ prompt, schema?, label? }) → { text, output?, usage }
+```
+
+- 每个子代理 = 独立 agent session:**同模型 + 同 core 工具,独立 store + 空上下文**(prompt 自带所需信息,不继承父对话——同 Claude Code subagent)。
+- `schema?`:结构化输出契约,结束时按 schema 解析 `output`;解析失败则 text 携带错误。
+- 子代理系统提示固定:"你是本次 run 的子代理,完成任务即返回结果文本,不要继续对话"。完成即停。
+
+### 3.2 workflow 工具(模型调用)
+
+```ts
+run_workflow({ items: [{ prompt, schema?, label? }], concurrency? })
+```
+
+- 并发默认 4、上限 8;单个执行器实例总代理上限 **64**(一次 `run_workflow` 调用或一次脚本运行的累计 spawn;3.5G 机器的保守值;Claude Code 为 16/1000)。
+- 聚合每个 item 的 `text` + `output` 进工具结果 → 主 loop 的普通 tool_result,自然进产品树/账本。
+- 执行器暴露**预算钩子**(loop 消费需要,§6):spawn 前查询预算,耗尽即拒绝新子代理。
+
+### 3.3 边界决策(与"同工具"的偏差及理由)
+
+1. **子代理工具 = read/write/edit/bash/grep/glob**。排除 workflow 工具自身(防递归);排除 product tools(history/todo——并行子代理写 todo_write 互相踩掉 run 快照)。
+2. **无插件**:子代理 session 不带 identity/task-guard/conversation-context 等插件(全是主 loop 语义),只带最小系统提示 + 工具。
+3. **取消**:子代理继承 run 的 abort signal,主 run 停止时全部终止。
+
+## 4. 事件契约
+
+### 4.1 child 内部事件(`CodingAgentLoopEvent` 新增)
+
+```ts
+{ type: "workflow_started",         workflowId, label, agentCount }
+{ type: "workflow_agent_started",   workflowId, agentId, label }
+{ type: "workflow_agent_completed", workflowId, agentId, label, ok, error?, usage? }
+{ type: "workflow_completed",       workflowId, ok, agentCount, totalTokens }
+```
+
+### 4.2 产品线(`CoreBackendEvent` 新增,与 child 1:1,payload 最小)
+
+- 完整结果(每个 agent 的 text + 解析 output)**只走工具结果**回主 loop(进产品树/账本);事件只带进度元数据(label/count/usage)。
+- 流转路径零新通道:child loop 事件 → 现有 envelope → RPC stdout → `mapRunEvent` 映射 → backend SSE fan-out → 前端监听。
+
+### 4.3 明确决策
+
+1. **无 stage 概念**(第一步是平铺扇出;第二步 A 的 `pipeline()` 引入阶段时再加 `stage` 字段)。
+2. **子代理的工具事件不上线**(agent 级事件足够;钻取留后续)。
+3. **事件不派生终态**:run 的 outcome 仍是唯一终态权威(沿用现有契约原则)。
+4. **仅 coding-agent 后端**产生这些事件(claude/pi/omp 无 workflow;union 共享但其他后端永不 emit)。
+5. 与 feat/agent-workspace 合并时,`CoreBackendEvent` union 两线都有新增,预期小冲突。
+
+## 5. 脚本求值器(第二步 A)
+
+### 5.1 形态
+
+```ts
+workflow_run({ script, args? })
+```
+
+脚本 = 带 top-level await 的 JS,只注入三个原语:
+
+```js
+const found = await agent("List every .ts under src/", { schema, label });
+const audits = await pipeline(found.files, f => agent(`Audit ${f}`, { label: f }));
+return audits;
+```
+
+### 5.2 沙箱边界
+
+- **受限求值**:`node:vm` + 白名单 context(不用 `new Function` 裸拼,不加依赖)。只注入 `agent` / `pipeline` / `args` / 内置类型工具;`require` / `process` / `fs` / `fetch` 一律不存在——脚本本身无文件系统与网络能力(同 Claude Code 约束)。
+- **超时**:脚本整体预算 60s,超时终止所有在飞子代理。
+- **上限由执行器统一强制**(并发 ≤8、总代理 ≤64),脚本无法绕过。
+- **错误**:脚本抛错 → 工具结果 isError + `workflow_completed(ok=false)`;已完成子代理结果丢弃(run 状态不恢复,已定)。
+
+### 5.3 脚本来源与落盘
+
+- 模型把脚本写到 workspace `.workflows/<name>.js`(可读、可改、可重跑)。
+- `workflow_run` 接受 script 文本直接执行;重跑 = 读文件再调。命令入口 `/<name>` 是后续阶段。
+- **执行器共享**:求值器的 `agent()` / `pipeline()` 直连 §3 的 `runSubagent` / `run_workflow`——事件、上限、预算钩子、取消全部复用同一通道,不重复实现。
+
+## 6. Loop 改造(首个消费者)
+
+方向:**loop = bundled workflow + 产品薄控制面**。持久状态载入脚本 meta,产品保留脚本永远不该有的东西。
+
+### 6.1 状态表示
+
+- workflow 脚本 = `meta`(每实例数据)+ `body`(纯逻辑,可重跑、可跨 loop 复用)。
+- **meta 载 loop 状态**:item 列表 + 各 item 步骤(7 步)+ verdict + 预算累计。每次 step 后回写。
+- 脚本文件落在 agent workspace(产品磁盘,持久)→ 状态跨 run/cron/崩溃存活;与"run 状态不恢复"决策不冲突(在飞代理照丢,落盘状态照存)。
+- INBOX.md(待处理输入)保留为独立文件(跨来源写入,非脚本产物)。
+
+### 6.2 产品控制面(脚本永远不该有的东西)
+
+1. **meta 写回必须过纯 reducer 校验**(9 action / 7 step 转移不变式):模型不能自由写状态;`packages/loop` 的 reducer 从"产品编排器"降级为"meta 写回校验器",代码主体保留。meta 校验器与执行器预算钩子必须和 workflow 地基同批落地,否则 loop 改造悬空。
+2. **评审门禁在调用之间**:workflow 的"无中途人工输入"约束不变;产品在两次触发间暂停等人工,不塞进脚本。
+3. **预算闸在执行器**:workflow 执行器的子代理 spawn 处挂钩产品预算(64 上限 ≠ 预算);meta 里记预算是账本,不是闸。
+4. **cron 触发 + git 回滚(step 间)+ 写锁**:照旧,全在产品。
+
+### 6.3 收益
+
+- generate → evaluate → 重试循环(现在每迭代两次产品 run)变成进程内脚本 `while` 循环:一个 spawn 替代 N 个,重试轮数脚本控制,item 生成并行扇出。
+- loop 成为 workflow 地基的首个消费者;未来 cron 扫描、类 deep-research 命令复用同一能力。
+
+## 7. 前端呈现
+
+- **进度卡**(对话画布内,复用瞬时状态模式,同 tool chip/todo 面板):workflow 运行中显示 label、`N/M agents`、每个代理一行(status/label)、累计 tokens、耗时;失败代理标红 + error 摘要;`workflow_completed` 到达 → 折叠态(一句话汇总)。
+- **状态与生命周期**:`useConversation` 加 `workflows: Map<workflowId, …>`,监听 §4 的 4 个 SSE 事件;卡片是瞬时进度(切会话/刷新即清)——持久真相 = 工具结果(产品树/账本)+ 模型合成的最终报告(现有渲染,零新组件)。
+- 无新路由/页面(v1);`/workflows` 式命令中心留到命令入口阶段。
+- **子代理钻取(v1 不做)**:卡片只到 agent 级。
+
+## 8. 实施顺序
+
+1. **Phase 1(子代理原语)**:`runSubagent` + `run_workflow` + 执行器(并发/上限/取消/预算钩子)+ §4 事件 + §7 前端进度卡。可独立验收:模型一句话扇出 20 个只读审计代理,前端看进度。
+2. **Phase 2(脚本运行时)**:`workflow_run` + vm 沙箱 + `.workflows/` 落盘。可独立验收:模型写脚本 → 执行 → 重跑。
+3. **Phase 3(loop 消费者)**:bundled loop workflow + meta 载状态 + reducer 校验写回 + 预算闸接线。验收:现有 loop 集成测试改造后全绿,行为等价 + 性能提升(每次迭代少一次 run)。
+
+## 9. 风险
+
+| 风险 | 缓解 |
+|---|---|
+| vm 沙箱逃逸 | 白名单 context + 无 fs/network 注入面 + 60s 预算;不引入 `new Function` 裸拼 |
+| 并行写冲突(共享 workspace) | 分片靠编排(prompt 划分不重叠文件);执行器并发上限 8;v1 不做文件级锁,冲突由模型分片纪律兜底 |
+| 子代理上下文成本(64 × 全上下文) | 子代理空上下文 + 最小提示;预算钩子(loop)与 64 上限兜底 |
+| meta 校验与执行器预算钩子未同批落地 → loop 悬空 | Phase 3 的前置条件写进 Phase 1 验收(预算钩子随执行器落地) |
+| 与 feat/agent-workspace 合并冲突 | 事件 union 两线新增,预期小冲突;workflow 不依赖 workspace 分支的 session-file/MCP mount |

--- a/packages/agent-backend/src/event.ts
+++ b/packages/agent-backend/src/event.ts
@@ -49,7 +49,7 @@ export type CoreBackendEvent =
       readonly label: string;
       readonly ok: boolean;
       readonly error?: string;
-      readonly usage?: Readonly<Record<string, unknown>>;
+      readonly usage?: unknown;
     }
   | {
       readonly type: "workflow_completed";

--- a/packages/agent-backend/src/event.ts
+++ b/packages/agent-backend/src/event.ts
@@ -29,7 +29,35 @@ export type CoreBackendEvent =
       readonly result?: Readonly<Record<string, unknown>>;
     }
   | { readonly type: "pending_action"; readonly actionId: string }
-  | { readonly type: "status"; readonly status: string };
+  | { readonly type: "status"; readonly status: string }
+  | {
+      readonly type: "workflow_started";
+      readonly workflowId: string;
+      readonly label: string;
+      readonly agentCount: number;
+    }
+  | {
+      readonly type: "workflow_agent_started";
+      readonly workflowId: string;
+      readonly agentId: string;
+      readonly label: string;
+    }
+  | {
+      readonly type: "workflow_agent_completed";
+      readonly workflowId: string;
+      readonly agentId: string;
+      readonly label: string;
+      readonly ok: boolean;
+      readonly error?: string;
+      readonly usage?: Readonly<Record<string, unknown>>;
+    }
+  | {
+      readonly type: "workflow_completed";
+      readonly workflowId: string;
+      readonly ok: boolean;
+      readonly agentCount: number;
+      readonly totalTokens: number;
+    };
 
 /** Opaque Backend-specific event. The kind segment must match the producing
  *  Backend's `backendKind`; the event segment is Backend-private. Usable for

--- a/packages/agent-backend/src/history.ts
+++ b/packages/agent-backend/src/history.ts
@@ -29,7 +29,6 @@ export interface AgentRunSnapshot<K extends string = string> {
   /** Skill pack roots (absolute dirs scanned for SKILL.md), frozen at Run
    *  creation. The Runtime loads them via the progressive skill plugin. */
   readonly skillRoots?: readonly string[];
-<<<<<<< HEAD
   /** The branch's CLI session reference (ADR 0003 decision 6): an opaque
    *  pointer the coding agent resolves itself (its own native session
    *  storage). Absent = fresh session. The product stores only this
@@ -38,10 +37,7 @@ export interface AgentRunSnapshot<K extends string = string> {
   /** Frozen permission_mode (ask/auto/deny), mapped per backend at
    *  dispatch (ADR 0020 decision 7). */
   readonly permissionMode?: "ask" | "auto" | "deny";
-=======
   /** Optional workflow budget (tokens) frozen at Run creation. */
   readonly workflowBudgetTokens?: number;
-  readonly productTools: readonly ProductToolDescriptor[];
->>>>>>> 8d65e63f (feat(agent-run): workflow budget frozen on runs and gated in the child)
   readonly configRevision: number;
 }

--- a/packages/agent-backend/src/history.ts
+++ b/packages/agent-backend/src/history.ts
@@ -29,6 +29,7 @@ export interface AgentRunSnapshot<K extends string = string> {
   /** Skill pack roots (absolute dirs scanned for SKILL.md), frozen at Run
    *  creation. The Runtime loads them via the progressive skill plugin. */
   readonly skillRoots?: readonly string[];
+<<<<<<< HEAD
   /** The branch's CLI session reference (ADR 0003 decision 6): an opaque
    *  pointer the coding agent resolves itself (its own native session
    *  storage). Absent = fresh session. The product stores only this
@@ -37,5 +38,10 @@ export interface AgentRunSnapshot<K extends string = string> {
   /** Frozen permission_mode (ask/auto/deny), mapped per backend at
    *  dispatch (ADR 0020 decision 7). */
   readonly permissionMode?: "ask" | "auto" | "deny";
+=======
+  /** Optional workflow budget (tokens) frozen at Run creation. */
+  readonly workflowBudgetTokens?: number;
+  readonly productTools: readonly ProductToolDescriptor[];
+>>>>>>> 8d65e63f (feat(agent-run): workflow budget frozen on runs and gated in the child)
   readonly configRevision: number;
 }

--- a/packages/agent-backend/src/mapping.test.ts
+++ b/packages/agent-backend/src/mapping.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { mapRunEvent } from "./mapping.js";
+
+describe("workflow event mapping", () => {
+  test("workflow lifecycle events map 1:1 to core events", () => {
+    expect(
+      mapRunEvent({
+        id: 1,
+        type: "workflow_started",
+        data: { workflowId: "wf1", label: "audit", agentCount: 12 },
+      }),
+    ).toEqual({ type: "workflow_started", workflowId: "wf1", label: "audit", agentCount: 12 });
+    expect(
+      mapRunEvent({
+        id: 2,
+        type: "workflow_agent_started",
+        data: { workflowId: "wf1", agentId: "a1", label: "src/a.ts" },
+      }),
+    ).toEqual({
+      type: "workflow_agent_started",
+      workflowId: "wf1",
+      agentId: "a1",
+      label: "src/a.ts",
+    });
+    expect(
+      mapRunEvent({
+        id: 3,
+        type: "workflow_agent_completed",
+        data: { workflowId: "wf1", agentId: "a1", label: "src/a.ts", ok: true },
+      }),
+    ).toEqual({
+      type: "workflow_agent_completed",
+      workflowId: "wf1",
+      agentId: "a1",
+      label: "src/a.ts",
+      ok: true,
+    });
+    expect(
+      mapRunEvent({
+        id: 4,
+        type: "workflow_completed",
+        data: { workflowId: "wf1", ok: false, agentCount: 12, totalTokens: 500 },
+      }),
+    ).toEqual({
+      type: "workflow_completed",
+      workflowId: "wf1",
+      ok: false,
+      agentCount: 12,
+      totalTokens: 500,
+    });
+  });
+
+  test("an errored agent carries error + usage through", () => {
+    const ev = mapRunEvent({
+      id: 5,
+      type: "workflow_agent_completed",
+      data: {
+        workflowId: "wf2",
+        agentId: "a2",
+        label: "x",
+        ok: false,
+        error: "boom",
+        usage: { totalTokens: 10 },
+      },
+    });
+    expect(ev).toEqual({
+      type: "workflow_agent_completed",
+      workflowId: "wf2",
+      agentId: "a2",
+      label: "x",
+      ok: false,
+      error: "boom",
+      usage: { totalTokens: 10 },
+    });
+  });
+});

--- a/packages/agent-backend/src/mapping.ts
+++ b/packages/agent-backend/src/mapping.ts
@@ -68,6 +68,40 @@ export function mapRunEvent(event: TransportRunEvent): BackendEvent<"coding_agen
       if (status === "stopped") return { type: "status", status: "aborted" };
       return { type: "status", status: "completed" };
     }
+    case "workflow_started":
+      return {
+        type: "workflow_started",
+        workflowId: String(event.data.workflowId ?? ""),
+        label: String(event.data.label ?? ""),
+        agentCount: Number(event.data.agentCount ?? 0),
+      };
+    case "workflow_agent_started":
+      return {
+        type: "workflow_agent_started",
+        workflowId: String(event.data.workflowId ?? ""),
+        agentId: String(event.data.agentId ?? ""),
+        label: String(event.data.label ?? ""),
+      };
+    case "workflow_agent_completed": {
+      const usage = event.data.usage as Readonly<Record<string, unknown>> | undefined;
+      return {
+        type: "workflow_agent_completed",
+        workflowId: String(event.data.workflowId ?? ""),
+        agentId: String(event.data.agentId ?? ""),
+        label: String(event.data.label ?? ""),
+        ok: event.data.ok === true,
+        ...(typeof event.data.error === "string" ? { error: event.data.error } : {}),
+        ...(usage ? { usage } : {}),
+      };
+    }
+    case "workflow_completed":
+      return {
+        type: "workflow_completed",
+        workflowId: String(event.data.workflowId ?? ""),
+        ok: event.data.ok === true,
+        agentCount: Number(event.data.agentCount ?? 0),
+        totalTokens: Number(event.data.totalTokens ?? 0),
+      };
     default:
       return {
         type: `backend.coding_agent.${event.type}`,

--- a/packages/agent/src/runtime/agent-event.ts
+++ b/packages/agent/src/runtime/agent-event.ts
@@ -34,7 +34,7 @@ export type CodingAgentLoopEvent =
       label: string;
       ok: boolean;
       error?: string;
-      usage?: Readonly<Record<string, unknown>>;
+      usage?: unknown;
     }
   | {
       type: "workflow_completed";

--- a/packages/agent/src/runtime/agent-event.ts
+++ b/packages/agent/src/runtime/agent-event.ts
@@ -24,6 +24,24 @@ export type CodingAgentLoopEvent =
   | { type: "compaction_end" }
   | { type: "queue_update" }
   | { type: "recap_update"; text: string; turn: number }
-  | { type: "todo_update"; items: readonly TodoItem[] };
+  | { type: "todo_update"; items: readonly TodoItem[] }
+  | { type: "workflow_started"; workflowId: string; label: string; agentCount: number }
+  | { type: "workflow_agent_started"; workflowId: string; agentId: string; label: string }
+  | {
+      type: "workflow_agent_completed";
+      workflowId: string;
+      agentId: string;
+      label: string;
+      ok: boolean;
+      error?: string;
+      usage?: Readonly<Record<string, unknown>>;
+    }
+  | {
+      type: "workflow_completed";
+      workflowId: string;
+      ok: boolean;
+      agentCount: number;
+      totalTokens: number;
+    };
 
 export type AgentLoopListener = (event: CodingAgentLoopEvent) => void | Promise<void>;

--- a/packages/loop/src/index.ts
+++ b/packages/loop/src/index.ts
@@ -1,4 +1,4 @@
-export { loopReducer } from "./loop-reducer.js";
+export { loopReducer, validateLoopMetaPatch } from "./loop-reducer.js";
 export type { LoopConfig } from "./state-md.js";
 export {
   formatInboxMd,

--- a/packages/loop/src/loop-reducer.test.ts
+++ b/packages/loop/src/loop-reducer.test.ts
@@ -478,7 +478,15 @@ describe("validateLoopMetaPatch", () => {
     loopId: "l1",
     lastRun: null,
     items: {
-      i1: { id: "i1", source: "src", summary: "s", step: "triaged", attempt: 0, priority: 1, result: null },
+      i1: {
+        id: "i1",
+        source: "src",
+        summary: "s",
+        step: "triaged",
+        attempt: 0,
+        priority: 1,
+        result: null,
+      },
     },
   };
 
@@ -507,7 +515,15 @@ describe("validateLoopMetaPatch", () => {
       ...base,
       items: {
         ...base.items,
-        i2: { id: "i2", source: "src", summary: "n", step: "fixing", attempt: 0, priority: 1, result: null },
+        i2: {
+          id: "i2",
+          source: "src",
+          summary: "n",
+          step: "fixing",
+          attempt: 0,
+          priority: 1,
+          result: null,
+        },
       },
     };
     const result = validateLoopMetaPatch(base, after);

--- a/packages/loop/src/loop-reducer.test.ts
+++ b/packages/loop/src/loop-reducer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { loopReducer } from "./loop-reducer.js";
+import { loopReducer, validateLoopMetaPatch } from "./loop-reducer.js";
 import type { LoopState } from "./types.js";
 
 function emptyState(): LoopState {
@@ -470,5 +470,84 @@ describe("loopReducer — immutability", () => {
     });
     const next = loopReducer(s, { type: "TICK" });
     expect(next.items).not.toBe(s.items);
+  });
+});
+
+describe("validateLoopMetaPatch", () => {
+  const base: LoopState = {
+    loopId: "l1",
+    lastRun: null,
+    items: {
+      i1: { id: "i1", source: "src", summary: "s", step: "triaged", attempt: 0, priority: 1, result: null },
+    },
+  };
+
+  test("a legal step advance passes", () => {
+    const after: LoopState = {
+      ...base,
+      items: { i1: { ...base.items.i1!, step: "fixing" } },
+    };
+    expect(validateLoopMetaPatch(base, after)).toEqual({ ok: true });
+  });
+
+  test("the REJECT retry edge verifying -> fixing is legal", () => {
+    const before: LoopState = {
+      ...base,
+      items: { i1: { ...base.items.i1!, step: "verifying" } },
+    };
+    const after: LoopState = {
+      ...before,
+      items: { i1: { ...before.items.i1!, step: "fixing", attempt: 1 } },
+    };
+    expect(validateLoopMetaPatch(before, after)).toEqual({ ok: true });
+  });
+
+  test("a new item must enter at triaged", () => {
+    const after: LoopState = {
+      ...base,
+      items: {
+        ...base.items,
+        i2: { id: "i2", source: "src", summary: "n", step: "fixing", attempt: 0, priority: 1, result: null },
+      },
+    };
+    const result = validateLoopMetaPatch(base, after);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toContain("must enter at triaged");
+  });
+
+  test("a backward step is rejected", () => {
+    const before: LoopState = {
+      ...base,
+      items: { i1: { ...base.items.i1!, step: "verifying" } },
+    };
+    const after: LoopState = {
+      ...before,
+      items: { i1: { ...before.items.i1!, step: "triaged" } },
+    };
+    const result = validateLoopMetaPatch(before, after);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toContain("cannot move");
+  });
+
+  test("item removal is rejected (the loop owns dismissal)", () => {
+    const after: LoopState = { ...base, items: {} };
+    const result = validateLoopMetaPatch(base, after);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toContain("removed");
+  });
+
+  test("unknown steps and verdicts are rejected", () => {
+    const badStep: LoopState = {
+      ...base,
+      items: { i1: { ...base.items.i1!, step: "nonsense" as never } },
+    };
+    expect(validateLoopMetaPatch(base, badStep).ok).toBe(false);
+    const badVerdict: LoopState = {
+      ...base,
+      items: {
+        i1: { ...base.items.i1!, result: { verdict: "MAYBE" as never, evidence: "e" } },
+      },
+    };
+    expect(validateLoopMetaPatch(base, badVerdict).ok).toBe(false);
   });
 });

--- a/packages/loop/src/loop-reducer.ts
+++ b/packages/loop/src/loop-reducer.ts
@@ -1,4 +1,4 @@
-import type { LoopAction, LoopState } from "./types.js";
+import type { ItemStep, LoopAction, LoopState } from "./types.js";
 
 type ReducerOpts = {
   maxRetries?: number;
@@ -193,7 +193,15 @@ const LEGAL_STEP_EDGES: Record<ItemStep, readonly ItemStep[]> = {
   resolved: [],
 };
 
-const ITEM_STEPS: readonly string[] = ["triaged", "fixing", "verifying", "awaiting_review", "resolved", "inbox", "promoted"];
+const ITEM_STEPS: readonly string[] = [
+  "triaged",
+  "fixing",
+  "verifying",
+  "awaiting_review",
+  "resolved",
+  "inbox",
+  "promoted",
+];
 const VERDICTS: readonly string[] = ["PASS", "REJECT", "ESCALATE"];
 
 /** Validate a workflow script's meta writeback against the pure state
@@ -214,7 +222,10 @@ export function validateLoopMetaPatch(
       return { ok: false, reason: `item ${id} has an unknown step: ${String(item.step)}` };
     }
     if (item.result && !VERDICTS.includes(item.result.verdict)) {
-      return { ok: false, reason: `item ${id} has an unknown verdict: ${String(item.result.verdict)}` };
+      return {
+        ok: false,
+        reason: `item ${id} has an unknown verdict: ${String(item.result.verdict)}`,
+      };
     }
     const prev = before.items[id];
     if (!prev) {

--- a/packages/loop/src/loop-reducer.ts
+++ b/packages/loop/src/loop-reducer.ts
@@ -177,3 +177,60 @@ export function loopReducer(state: LoopState, action: LoopAction, opts?: Reducer
 
   return { ...state, items };
 }
+
+// ─── Meta writeback validation (workflow consumer) ─────────────────────
+
+/** The state machine's step edges. REJECT retries legitimately move
+ *  verifying → fixing (a "backward" edge in any linear order), so the
+ *  validator uses the EDGE SET, not a sequence index. */
+const LEGAL_STEP_EDGES: Record<ItemStep, readonly ItemStep[]> = {
+  inbox: ["promoted", "triaged"],
+  promoted: ["triaged"],
+  triaged: ["fixing"],
+  fixing: ["verifying"],
+  verifying: ["resolved", "awaiting_review", "fixing", "inbox"],
+  awaiting_review: ["resolved", "inbox"],
+  resolved: [],
+};
+
+const ITEM_STEPS: readonly string[] = ["triaged", "fixing", "verifying", "awaiting_review", "resolved", "inbox", "promoted"];
+const VERDICTS: readonly string[] = ["PASS", "REJECT", "ESCALATE"];
+
+/** Validate a workflow script's meta writeback against the pure state
+ *  machine invariants. The model can never free-write loop state: only
+ *  ADD_ITEM semantics (new ids entering at `triaged`) and legal step
+ *  edges are accepted; item removal is rejected (the loop owns dismissal). */
+export function validateLoopMetaPatch(
+  before: LoopState,
+  after: LoopState,
+): { ok: true } | { ok: false; reason: string } {
+  for (const id of Object.keys(before.items)) {
+    if (!(id in after.items)) {
+      return { ok: false, reason: `item ${id} was removed - the loop owns dismissal` };
+    }
+  }
+  for (const [id, item] of Object.entries(after.items)) {
+    if (!ITEM_STEPS.includes(item.step)) {
+      return { ok: false, reason: `item ${id} has an unknown step: ${String(item.step)}` };
+    }
+    if (item.result && !VERDICTS.includes(item.result.verdict)) {
+      return { ok: false, reason: `item ${id} has an unknown verdict: ${String(item.result.verdict)}` };
+    }
+    const prev = before.items[id];
+    if (!prev) {
+      // New item: the ADD_ITEM contract enters at `triaged` only.
+      if (item.step !== "triaged") {
+        return { ok: false, reason: `new item ${id} must enter at triaged, got ${item.step}` };
+      }
+      continue;
+    }
+    if (prev.step === item.step) continue; // field-only patches (result/attempt)
+    if (!LEGAL_STEP_EDGES[prev.step].includes(item.step)) {
+      return {
+        ok: false,
+        reason: `item ${id} cannot move ${prev.step} -> ${item.step}`,
+      };
+    }
+  }
+  return { ok: true };
+}

--- a/skills/loop-workflow/SKILL.md
+++ b/skills/loop-workflow/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: loop-workflow
+description: >
+  Drive one loop generation round as an in-process workflow: fan out fixes
+  per item, self-evaluate each with a verdict agent, retry bounded by the
+  item attempt budget. The product validates the meta writeback.
+user_invocable: false
+---
+
+# Loop Workflow
+
+One loop step = one `workflow_run` invocation. The script below is the
+canonical orchestration; copy it into `.workflows/loop.js` in the agent
+workspace and adapt per-loop.
+
+## Contract with the product
+
+- `meta.items` carries the loop's per-instance state (item id/summary/
+  step/attempt). The product seeds it from STATE.md before the run.
+- After the run, the product reads the script's `meta` and validates the
+  writeback with `validateLoopMetaPatch` (packages/loop). Only legal
+  step edges and `triaged`-entry additions are accepted; removals and
+  regressions are rejected.
+- You never free-write state: the product is the only meta authority.
+
+## Rules
+
+- Each item gets ONE generation agent (smallest possible diff) and ONE
+  evaluator agent (assume the fix is broken until tests prove otherwise).
+- Retry at most the item's remaining attempt budget; two no-progress
+  rounds stop the workflow.
+- Subagents share the workspace: shard by file so parallel fixes never
+  overlap.
+- Budget: the workflow executor enforces the product budget gate; the
+  script must not spawn unbounded agents.

--- a/skills/loop-workflow/workflow.js
+++ b/skills/loop-workflow/workflow.js
@@ -1,0 +1,45 @@
+// Loop workflow template: meta (per-instance state, product-owned) +
+// body (pure orchestration). The product seeds meta from STATE.md and
+// validates the writeback with validateLoopMetaPatch - never trust a
+// model-written state transition.
+export const meta = {
+  name: "loop-workflow",
+  // Per-instance loop state. Shape: Record<itemId, {id, source, summary,
+  // step, attempt, priority, result}>. step is one of triaged | fixing |
+  // verifying | awaiting_review | resolved | inbox | promoted.
+  items: {},
+  // Advisory bookkeeping; the real budget gate lives in the executor.
+  budgetSpent: 0,
+};
+
+// Candidates: items the generator may work on this round.
+const candidates = Object.values(meta.items).filter(
+  (item) => item.step === "triaged" || item.step === "fixing",
+);
+
+const results = await pipeline(candidates, async (item) => {
+  const fix = await agent(
+    `Fix loop item ${item.id}: ${item.summary}. Smallest possible diff; do not commit.`,
+    { label: `${item.id}-fix` },
+  );
+  const verdict = await agent(
+    `Verify the fix for item ${item.id}. Run the relevant tests and return JSON: {"verdict":"PASS"|"REJECT"|"ESCALATE","evidence":"..."}.`,
+    {
+      label: `${item.id}-verify`,
+      schema: {
+        type: "object",
+        properties: {
+          verdict: { type: "string", enum: ["PASS", "REJECT", "ESCALATE"] },
+          evidence: { type: "string" },
+        },
+        required: ["verdict", "evidence"],
+      },
+    },
+  );
+  // The product maps each result onto the legal step edge:
+  // PASS -> verifying -> awaiting_review/resolved; REJECT -> fixing retry
+  // (bounded by attempt) or inbox; ESCALATE -> inbox.
+  return { id: item.id, fixText: fix.text, verdict: verdict.output };
+});
+
+return results;

--- a/skills/workflow-authoring/SKILL.md
+++ b/skills/workflow-authoring/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: workflow-authoring
+description: >
+  Write and run workflow scripts (run_workflow fan-out or workflow_run
+  orchestration scripts) for large-scale subagent tasks: audits, migrations,
+  multi-source research, fix-until-pass loops.
+user_invocable: true
+---
+
+# Workflow Authoring
+
+You have two workflow tools. Choose the simpler one that fits.
+
+## run_workflow — flat fan-out
+
+For independent tasks: `run_workflow({ label, items: [{prompt, label?, schema?}] })`.
+
+- Each item = one isolated subagent (same model + file tools, fresh context).
+- The tool returns per-item `{label, text, output?, ok, error?}` plus totals.
+- Use `schema` when you need structured results: the subagent's final text
+  is JSON-parsed into `output`; a non-JSON result marks that item failed.
+
+## workflow_run — orchestration script
+
+For loops/branches/intermediate state. The script is top-level-await JS:
+
+```js
+const found = await agent("List every .ts under src/", { schema: {...} });
+const audits = await pipeline(found.output.files, (f) => agent(`Audit ${f}`, { label: f }));
+return audits;
+```
+
+**Primitives** (the ONLY globals):
+- `agent(prompt, {schema?, label?})` → `{label, text, output, ok, error, usage}`
+- `pipeline(items, fn)` → runs `fn` per item (executor-capped concurrency)
+- `args` — the `args` object you pass to `workflow_run`
+- `return <value>` — the value lands in the tool result as `value`
+
+**Sandbox limits** — the script has NO `fs`, `process`, `require`, `fetch`.
+Agents do the work; the script only orchestrates. 60s script budget;
+8 concurrent / 64 total agents per run (enforced, not bypassable).
+A thrown error or timeout fails the whole call.
+
+**Saving scripts**: pass `name` to `workflow_run` — the script persists to
+`.workflows/<name>.js` in the workspace. Read it back later and re-run the
+same orchestration.
+
+## Patterns
+
+- **Audit fan-out**: one agent lists targets, `pipeline` reviews each, a
+  final `agent` dedupes/ranks the findings.
+- **Fix until pass**: `while` loop: run the check via an agent, retry fixes
+  until PASS or two no-progress rounds.
+- **Parallel migration**: fan out one agent per file, each in its own scope;
+  never let two items edit the same file (shard in the prompts).
+
+## Rules
+
+- Subagents inherit the workspace: write conflicts are YOUR sharding
+  responsibility.
+- Keep per-item prompts self-contained (subagents see no parent context).
+- Prefer `run_workflow` unless you need a loop or an intermediate value.

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -5,5 +5,5 @@
     "types": ["bun"]
   },
   "include": ["_template/**/*.ts", "apps/**/*.ts", "packages/**/*.ts", "scripts/**/*.ts"],
-  "exclude": ["**/dist/**", "**/node_modules/**"]
+  "exclude": ["**/dist/**", "**/node_modules/**", "**/.backend-data/**"]
 }


### PR DESCRIPTION
## Summary

Coding-agent dynamic workflow (Claude Code style) + the backend loop as its first consumer. 18 commits, gates green (typecheck 42/42, lint 23/23, test 42/42), real-model verified.

## What landed

**Phase 1 - subagent fan-out**
- `run_workflow` tool: in-process subagent executor (same model + file tools, isolated store/context, no plugins, no product/workflow tools), concurrency ≤8 / total ≤64, budget gate, abort propagation
- Workflow lifecycle events on the wire (`workflow_started/agent_started/agent_completed/completed`) → backend SSE → web progress card
- E2E: fake provider drives a real fan-out, full event stream asserted

**Phase 2 - orchestration scripts**
- `workflow_run` tool: `node:vm` sandbox (only `agent`/`pipeline`/`args`; no fs/process/require), 60s budget, sync-loop + async-stall timeouts
- Scripts persist to `.workflows/<name>.js`; schema-parsed subagent outputs; gate failures propagate workflow-level

**Phase 3 - loop as the first consumer**
- Builtin `workflow-authoring` skill + builtin skills always in every run's skillRoots (real-model test: the agent discovered the skill, ran a 11-subagent audit)
- Loop: ONE generator run per item drives the seeded workflow (`.workflows/loop.js`, meta carries the item state); the model writes the verdict back into the meta, the product validates it with `validateLoopMetaPatch` (pure reducer invariants: legal step edges, triaged entry, no removal) and applies the transition. The separate evaluator Run, VERDICT.md, and evaluator scope are gone; per-item git rollback + denylist stay product-side
- `workflowBudgetTokens` frozen on runs (migration 0025): the child gates subagent spawns against the loop's remaining daily budget

## Notes

- Real-child integration test drives the full loop chain (commit → skill_load → meta writeback → PASS)
- Loop rollback semantics kept per item by keeping one workflow per item; all-item fan-out is a later refinement
