### PR TITLE
feat(backend): project worktrees - many-to-many agent-project (ADR 0023)

### DIFF
--- a/apps/backend/drizzle/backend/0032_project_worktree.sql
+++ b/apps/backend/drizzle/backend/0032_project_worktree.sql
@@ -1,0 +1,3 @@
+ALTER TABLE conversation ADD COLUMN project_id text REFERENCES project(project_id) ON DELETE RESTRICT;
+--> statement-breakpoint
+ALTER TABLE project DROP COLUMN auto_orchestrate;

--- a/apps/backend/drizzle/backend/meta/_journal.json
+++ b/apps/backend/drizzle/backend/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1786606000000,
       "tag": "0031_workflow_budget",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1786700000000,
+      "tag": "0032_project_worktree",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/bootstrap/features.ts
+++ b/apps/backend/src/bootstrap/features.ts
@@ -49,12 +49,12 @@ import {
   sqliteProductToolCallAdapter,
 } from "../features/product-tools/index.js";
 import { createRunTokenRegistry } from "../features/product-tools/run-token-registry.js";
-import { ensureMirror, ensureWorktree } from "../features/project/worktree.js";
 import {
   createProjectService,
   projectRoutes,
   sqliteProjectAdapter,
 } from "../features/project/index.js";
+import { ensureMirror, ensureWorktree } from "../features/project/worktree.js";
 import { createRuntimeOpsService, opsRoutes } from "../features/runtime-ops/index.js";
 import { settingsRoutes } from "../features/settings/index.js";
 import type { SkillPackRow } from "../features/skill-pack/index.js";
@@ -657,7 +657,7 @@ export async function installFeatures(services: BackendServices): Promise<Instal
       getSetupManager,
       (id: string) => projectSvc.exists(id),
     ),
-    conversations: conversationRoutes(conv.convSvc, ulid, conv.goalStore),
+    conversations: conversationRoutes(conv.convSvc, ulid, conv.goalStore, (id: string) => projectSvc.exists(id)),
     ops: opsRoutes(opsSvc),
     agentRuns: agentRunRoutes({ db, agentRunService, agentRunExecution }),
     projects: projectRoutes(projectSvc),

--- a/apps/backend/src/bootstrap/features.ts
+++ b/apps/backend/src/bootstrap/features.ts
@@ -55,6 +55,7 @@ import {
   sqliteProjectAdapter,
 } from "../features/project/index.js";
 import { ensureMirror, ensureWorktree } from "../features/project/worktree.js";
+import { createWorktreeOps } from "../features/project/worktree-ops.js";
 import { createRuntimeOpsService, opsRoutes } from "../features/runtime-ops/index.js";
 import { settingsRoutes } from "../features/settings/index.js";
 import type { SkillPackRow } from "../features/skill-pack/index.js";
@@ -673,6 +674,18 @@ export async function installFeatures(services: BackendServices): Promise<Instal
 
   // ─── FeatureSet ─────────────────────────────────────────────
 
+  // Worktree read/merge ops over the project mirrors (ADR 0023 P2).
+  const worktreeOps = createWorktreeOps({
+    dataDir: config.dataDir,
+    projectPort,
+    listAgentConfigs: async () =>
+      (await agentSvc.list(true)).map((a) => ({
+        id: a.id,
+        workspacePath: a.workspacePath,
+        projects: a.config.runtime_config.projects,
+      })),
+  });
+
   const featureSet: FeatureSet = {
     agents: agentRoutes(
       agentSvc,
@@ -698,7 +711,7 @@ export async function installFeatures(services: BackendServices): Promise<Instal
     ),
     ops: opsRoutes(opsSvc),
     agentRuns: agentRunRoutes({ db, agentRunService, agentRunExecution }),
-    projects: projectRoutes(projectSvc),
+    projects: projectRoutes(projectSvc, worktreeOps),
     loops: loopRoutes({
       agentWorkspaceOf: resolveAgentWorkspace,
       cronSvc,

--- a/apps/backend/src/bootstrap/features.ts
+++ b/apps/backend/src/bootstrap/features.ts
@@ -649,7 +649,16 @@ export async function installFeatures(services: BackendServices): Promise<Instal
     },
   });
 
+  /** LOOP.md agent ids -> agent workspace paths (ADR 0023 P2). */
+  const resolveAgentWorkspace = async (id: string): Promise<string | null> => {
+    const agent = await agentSvc.getById(id).catch(() => null);
+    return agent?.workspacePath ?? null;
+  };
+  console.info(
+    `[bootstrap] loop steps now use per-agent worktrees; legacy clones under ${config.dataDir}/repos are no longer read and may be deleted manually`,
+  );
   const cronScheduler = createCronScheduler({
+    agentWorkspaceOf: resolveAgentWorkspace,
     cronSvc,
     config,
     convPort,
@@ -691,6 +700,7 @@ export async function installFeatures(services: BackendServices): Promise<Instal
     agentRuns: agentRunRoutes({ db, agentRunService, agentRunExecution }),
     projects: projectRoutes(projectSvc),
     loops: loopRoutes({
+      agentWorkspaceOf: resolveAgentWorkspace,
       cronSvc,
       scheduler: cronScheduler,
       dataDir: config.dataDir,

--- a/apps/backend/src/bootstrap/features.ts
+++ b/apps/backend/src/bootstrap/features.ts
@@ -54,7 +54,7 @@ import {
   projectRoutes,
   sqliteProjectAdapter,
 } from "../features/project/index.js";
-import { ensureMirror, ensureWorktree } from "../features/project/worktree.js";
+import { ensureMirror, ensureWorktree, removeWorktree } from "../features/project/worktree.js";
 import { createWorktreeOps } from "../features/project/worktree-ops.js";
 import { createRuntimeOpsService, opsRoutes } from "../features/runtime-ops/index.js";
 import { settingsRoutes } from "../features/settings/index.js";
@@ -159,13 +159,16 @@ export async function installFeatures(services: BackendServices): Promise<Instal
   const busyGuard: { check: ((agentId: string) => void) | undefined } = { check: undefined };
   // Workspace bridge (ADR 0003 decision 3): reconcile skills/mcp into the
   // agent workspace. Late-bound (mcpSvc is created further down).
-  const reconcileAgent: { fn: (agentId: string) => Promise<void> } = { fn: async () => {} };
+  const reconcileAgent: {
+    fn: (agentId: string, prevProjects?: string[]) => Promise<void>;
+  } = { fn: async () => {} };
   const agentSvc = createAgentSvc(db, config, larkBotRegistry, {
     onAgentCreate: async (agentId: string) => {
       await skillPackSvc.setAgentPacks(agentId, ["builtin"]);
       await reconcileAgent.fn(agentId);
     },
-    onAgentUpdate: (agentId: string) => reconcileAgent.fn(agentId),
+    onAgentUpdate: (agentId: string, prevProjects: string[]) =>
+      reconcileAgent.fn(agentId, prevProjects),
     assertNoActiveRun: (agentId: string) => busyGuard.check?.(agentId),
   });
 
@@ -534,9 +537,39 @@ export async function installFeatures(services: BackendServices): Promise<Instal
     return ids;
   }
 
-  reconcileAgent.fn = async (agentId: string): Promise<void> => {
+  reconcileAgent.fn = async (agentId: string, prevProjects?: string[]): Promise<void> => {
     try {
       const agent = await agentSvc.getById(agentId);
+      // Detach cleanup (ADR 0023): projects removed since the previous
+      // config get their worktree + branch removed.
+      if (prevProjects) {
+        const removed = prevProjects.filter(
+          (pid) => !agent.config.runtime_config.projects.includes(pid),
+        );
+        for (const pid of removed) {
+          const project = projectSvc.getById(pid);
+          if (!project?.repoUrl) continue;
+          try {
+            const mirror = await ensureMirror(config.dataDir, {
+              projectId: project.projectId,
+              repoUrl: project.repoUrl,
+              defaultBranch: project.defaultBranch,
+            });
+            await removeWorktree(
+              mirror,
+              agent.workspacePath,
+              {
+                projectId: project.projectId,
+                repoUrl: project.repoUrl,
+                defaultBranch: project.defaultBranch,
+              },
+              agentId,
+            );
+          } catch (err) {
+            console.warn(`[reconcile] detach cleanup for ${agentId}/${pid} failed:`, err);
+          }
+        }
+      }
       const packs = await skillPackPort.listForAgent(agentId);
       const assignedKnowledge = agent.config.runtime_config.knowledge_packs
         .map((packId) => knowledgeSvc.getById(packId))

--- a/apps/backend/src/bootstrap/features.ts
+++ b/apps/backend/src/bootstrap/features.ts
@@ -49,6 +49,7 @@ import {
   sqliteProductToolCallAdapter,
 } from "../features/product-tools/index.js";
 import { createRunTokenRegistry } from "../features/product-tools/run-token-registry.js";
+import { ensureMirror, ensureWorktree } from "../features/project/worktree.js";
 import {
   createProjectService,
   projectRoutes,
@@ -512,7 +513,38 @@ export async function installFeatures(services: BackendServices): Promise<Instal
       const assignedKnowledge = agent.config.runtime_config.knowledge_packs
         .map((packId) => knowledgeSvc.getById(packId))
         .filter((p): p is NonNullable<typeof p> => p !== null && p.status === "ready");
+      // ADR 0023: materialize a worktree per attached project and bridge
+      // the same mcp + product-tools config into it. Failures warn, never
+      // throw (reconcile stays best-effort like the other bridges).
+      const extraRoots: string[] = [];
+      for (const pid of agent.config.runtime_config.projects) {
+        const project = projectSvc.getById(pid);
+        if (!project?.repoUrl) {
+          console.warn(
+            `[reconcile] agent ${agentId}: project ${pid} missing or no repoUrl, skipped`,
+          );
+          continue;
+        }
+        const wp = {
+          projectId: project.projectId,
+          repoUrl: project.repoUrl,
+          defaultBranch: project.defaultBranch,
+        };
+        try {
+          const mirror = await ensureMirror(config.dataDir, wp);
+          const wt = await ensureWorktree(mirror, agent.workspacePath, wp, agentId);
+          if (wt) extraRoots.push(wt);
+          else {
+            console.warn(
+              `[reconcile] agent ${agentId}: worktree slot for ${pid} occupied, skipped`,
+            );
+          }
+        } catch (err) {
+          console.warn(`[reconcile] agent ${agentId}: worktree for ${pid} failed:`, err);
+        }
+      }
       reconcileAgentResources({
+        extraRoots,
         workspacePath: agent.workspacePath,
         kind: agent.config.runtime_config.runtime,
         skillPacks: packs

--- a/apps/backend/src/bootstrap/features.ts
+++ b/apps/backend/src/bootstrap/features.ts
@@ -623,6 +623,7 @@ export async function installFeatures(services: BackendServices): Promise<Instal
       identityStore,
       (id: string) => larkBotRegistry.statusOf(id),
       getSetupManager,
+      (id: string) => projectSvc.exists(id),
     ),
     conversations: conversationRoutes(conv.convSvc, ulid, conv.goalStore),
     ops: opsRoutes(opsSvc),

--- a/apps/backend/src/bootstrap/features.ts
+++ b/apps/backend/src/bootstrap/features.ts
@@ -394,9 +394,8 @@ export async function installFeatures(services: BackendServices): Promise<Instal
       const members = conv.convPort.getMembers(conversationId);
       const member = members.find((m) => m.memberId === agentMemberId);
       const agent = member?.agentId ? await agentSvc.getById(member.agentId) : null;
-      const access = agent?.config.runtime_config.permission_mode === "ask"
-        ? "read_only"
-        : "read_write";
+      const access =
+        agent?.config.runtime_config.permission_mode === "ask" ? "read_only" : "read_write";
       // Project-bound conversation (ADR 0023): cwd is the agent's worktree
       // for that project; context (skills/prompt/token) still comes from
       // the agent workspace. Not attached = explicit dispatch failure.
@@ -464,7 +463,18 @@ export async function installFeatures(services: BackendServices): Promise<Instal
   // ─── Project ────────────────────────────────────────────────
 
   const projectPort = sqliteProjectAdapter(db);
-  const projectSvc = createProjectService({ port: projectPort, idGen: ulid });
+  const projectSvc = createProjectService({
+    port: projectPort,
+    idGen: ulid,
+    // Detach guard (ADR 0023): refuse deleting a project agents still
+    // attach to. agentSvc.list returns rows carrying the materialized
+    // config cache; includeArchived covers archived agents too.
+    listAgentConfigs: async () =>
+      (await agentSvc.list(true)).map((a) => ({
+        id: a.id,
+        projects: a.config.runtime_config.projects,
+      })),
+  });
 
   // ─── MCP ────────────────────────────────────────────────────
 

--- a/apps/backend/src/bootstrap/features.ts
+++ b/apps/backend/src/bootstrap/features.ts
@@ -394,9 +394,26 @@ export async function installFeatures(services: BackendServices): Promise<Instal
       const members = conv.convPort.getMembers(conversationId);
       const member = members.find((m) => m.memberId === agentMemberId);
       const agent = member?.agentId ? await agentSvc.getById(member.agentId) : null;
+      const access = agent?.config.runtime_config.permission_mode === "ask"
+        ? "read_only"
+        : "read_write";
+      // Project-bound conversation (ADR 0023): cwd is the agent's worktree
+      // for that project; context (skills/prompt/token) still comes from
+      // the agent workspace. Not attached = explicit dispatch failure.
+      const convRow = conv.convPort.getConversation(conversationId);
+      if (convRow?.projectId) {
+        if (!agent?.config.runtime_config.projects.includes(convRow.projectId)) {
+          throw new Error(
+            `agent ${member?.agentId ?? "?"} has not attached project ${convRow.projectId}; ` +
+              `attach it via the agent update API (agent.yml runtime_config.projects)`,
+          );
+        }
+        const worktree = join(agent.workspacePath, "projects", convRow.projectId);
+        return { root: worktree, access };
+      }
       return {
         root: agent?.workspacePath ?? config.workspaceRoot,
-        access: agent?.config.runtime_config.permission_mode === "ask" ? "read_only" : "read_write",
+        access,
       };
     },
     productToolsEntrypoint: config.productToolsMcpUrl
@@ -657,7 +674,9 @@ export async function installFeatures(services: BackendServices): Promise<Instal
       getSetupManager,
       (id: string) => projectSvc.exists(id),
     ),
-    conversations: conversationRoutes(conv.convSvc, ulid, conv.goalStore, (id: string) => projectSvc.exists(id)),
+    conversations: conversationRoutes(conv.convSvc, ulid, conv.goalStore, (id: string) =>
+      projectSvc.exists(id),
+    ),
     ops: opsRoutes(opsSvc),
     agentRuns: agentRunRoutes({ db, agentRunService, agentRunExecution }),
     projects: projectRoutes(projectSvc),

--- a/apps/backend/src/features/agent-run/execution.test.ts
+++ b/apps/backend/src/features/agent-run/execution.test.ts
@@ -11,11 +11,11 @@ import { assistantMessageId, parseMessageRevision } from "@my-agent-team/message
 import { openDb } from "../../infra/sqlite/db.js";
 import { createAgentContextService, sqliteAgentContextAdapter } from "../agent-context/index.js";
 import { sqliteConversationAdapter } from "../conversation/adapter-sqlite.js";
-import { sqliteProjectAdapter } from "../project/adapter-sqlite.js";
 import {
   createRunTokenRegistry,
   type RunTokenRegistry,
 } from "../product-tools/run-token-registry.js";
+import { sqliteProjectAdapter } from "../project/adapter-sqlite.js";
 import { sqliteAgentRunAdapter } from "./adapter-sqlite.js";
 import type { AgentRun } from "./domain.js";
 import { createAgentRunExecutionService, runEventStreamFor } from "./execution.js";
@@ -971,7 +971,13 @@ describe("agent run execution (Run-centric)", () => {
     const projectPort = sqliteProjectAdapter(db);
     for (const pid of ["p-attached", "p-other"]) {
       if (!projectPort.getProject(pid)) {
-        projectPort.createProject({ projectId: pid, name: pid, createdAt: Date.now() });
+        projectPort.createProject({
+          projectId: pid,
+          name: pid,
+          repoUrl: null,
+          defaultBranch: null,
+          createdAt: Date.now(),
+        });
       }
     }
     convPort.createConversation({
@@ -1006,7 +1012,13 @@ describe("agent run execution (Run-centric)", () => {
   test("project-bound conversation with unattached project fails explicitly", async () => {
     const projectPort2 = sqliteProjectAdapter(db);
     if (!projectPort2.getProject("p-other")) {
-      projectPort2.createProject({ projectId: "p-other", name: "p-other", createdAt: Date.now() });
+      projectPort2.createProject({
+        projectId: "p-other",
+        name: "p-other",
+        repoUrl: null,
+        defaultBranch: null,
+        createdAt: Date.now(),
+      });
     }
     convPort.createConversation({
       conversationId: "conv-unattached",

--- a/apps/backend/src/features/agent-run/execution.test.ts
+++ b/apps/backend/src/features/agent-run/execution.test.ts
@@ -11,6 +11,7 @@ import { assistantMessageId, parseMessageRevision } from "@my-agent-team/message
 import { openDb } from "../../infra/sqlite/db.js";
 import { createAgentContextService, sqliteAgentContextAdapter } from "../agent-context/index.js";
 import { sqliteConversationAdapter } from "../conversation/adapter-sqlite.js";
+import { sqliteProjectAdapter } from "../project/adapter-sqlite.js";
 import {
   createRunTokenRegistry,
   type RunTokenRegistry,
@@ -147,7 +148,20 @@ function makeExecution(
       },
     },
     idGen: { ulid: () => `id-${Math.random().toString(36).slice(2, 12)}` },
-    resolveWorkspace: async () => ({ root: dataDir, access: "read_write" }),
+    resolveWorkspace: async ({ conversationId: cid }) => {
+      // Mirrors the composition root: a project-bound conversation maps
+      // to the agent's worktree; not attached = explicit failure.
+      const convRow = convPort.getConversation(cid);
+      if (convRow?.projectId) {
+        if (convRow.projectId !== "p-attached") {
+          throw new Error(
+            `agent has not attached project ${convRow.projectId}; attach it via the agent update API (agent.yml runtime_config.projects)`,
+          );
+        }
+        return { root: join(dataDir, "projects", convRow.projectId), access: "read_write" };
+      }
+      return { root: dataDir, access: "read_write" };
+    },
     productToolsEntrypoint: "sse:http://127.0.0.1:1/mcp",
     productToolsTokenRegistry: tokenRegistry ?? createRunTokenRegistry(),
   });
@@ -950,5 +964,78 @@ describe("agent run execution (Run-centric)", () => {
     await dispatchPromise;
     expect(fake.stopCalls).toEqual([runId]);
     await waitForTerminal(runId);
+  }, 15_000);
+
+  test("project-bound conversation runs with cwd = the worktree", async () => {
+    mkdirSync(join(dataDir, "projects", "p-attached"), { recursive: true });
+    const projectPort = sqliteProjectAdapter(db);
+    for (const pid of ["p-attached", "p-other"]) {
+      if (!projectPort.getProject(pid)) {
+        projectPort.createProject({ projectId: pid, name: pid, createdAt: Date.now() });
+      }
+    }
+    convPort.createConversation({
+      conversationId: "conv-proj",
+      createdAt: Date.now(),
+      projectId: "p-attached",
+    });
+    convPort.addMember({
+      conversationId: "conv-proj",
+      memberId: agentMemberId,
+      kind: "agent",
+      agentId: "agent-1",
+      joinedAt: Date.now(),
+    });
+    const fake = createFakeDaemon();
+    const execution = makeExecution(fake);
+    const acquired = await backend.enqueueAndAcquire({
+      conversationId: "conv-proj",
+      agentMemberId,
+      backendKind: "coding_agent",
+      mode: "normal",
+      message: { role: "user", text: "in project" },
+      defaultModel: { backendKind: "coding_agent", modelId: "fake/echo" },
+      configRevision: 1,
+      idempotencyKey: "proj-1",
+    });
+    await execution.dispatch(acquired.run!.runId);
+    await waitForTerminal(acquired.run!.runId);
+    expect(fake.executeCalls[0]?.workspaceRoot).toBe(join(dataDir, "projects", "p-attached"));
+  }, 15_000);
+
+  test("project-bound conversation with unattached project fails explicitly", async () => {
+    const projectPort2 = sqliteProjectAdapter(db);
+    if (!projectPort2.getProject("p-other")) {
+      projectPort2.createProject({ projectId: "p-other", name: "p-other", createdAt: Date.now() });
+    }
+    convPort.createConversation({
+      conversationId: "conv-unattached",
+      createdAt: Date.now(),
+      projectId: "p-other",
+    });
+    convPort.addMember({
+      conversationId: "conv-unattached",
+      memberId: agentMemberId,
+      kind: "agent",
+      agentId: "agent-1",
+      joinedAt: Date.now(),
+    });
+    const fake = createFakeDaemon();
+    const execution = makeExecution(fake);
+    const acquired = await backend.enqueueAndAcquire({
+      conversationId: "conv-unattached",
+      agentMemberId,
+      backendKind: "coding_agent",
+      mode: "normal",
+      message: { role: "user", text: "nope" },
+      defaultModel: { backendKind: "coding_agent", modelId: "fake/echo" },
+      configRevision: 1,
+      idempotencyKey: "proj-2",
+    });
+    await expect(execution.dispatch(acquired.run!.runId)).rejects.toThrow(
+      /has not attached project p-other/,
+    );
+    const run = await waitForTerminal(acquired.run!.runId);
+    expect(run.status).toBe("failed");
   }, 15_000);
 });

--- a/apps/backend/src/features/agent-run/execution.ts
+++ b/apps/backend/src/features/agent-run/execution.ts
@@ -147,6 +147,9 @@ export function createAgentRunExecutionService(
    *  subscription. Removed when the run reaches a terminal state. */
   const liveRuns = new Map<string, LiveRun>();
   const inflight = new Set<string>();
+  /** Worktree roots with a live dispatch (ADR 0023 §5): same-root runs
+   *  queue instead of racing the same checkout. Keyed by workspace root. */
+  const rootLocks = new Map<string, Promise<void>>();
   /** Dispatch promises by runId: dispose() drains them AFTER the children
    *  are dead so the DB is never closed mid-finalize. */
   const inflightPromises = new Map<string, Promise<void>>();
@@ -510,7 +513,29 @@ export function createAgentRunExecutionService(
           "agent-run",
           `input_claimed runId=${runId} inputId=${claimed.input.inputId} mode=${claimed.input.mode}`,
         );
-        const { outcome, segment, drain } = await deliverInput(run, claimed, stage);
+        // Same-worktree runs serialize (ADR 0023 §5): a shared checkout
+        // must never host two concurrent children.
+        const workspace0 =
+          run.workspace ??
+          (await resolveWorkspace({
+            conversationId: run.conversationId,
+            agentMemberId: run.agentMemberId,
+          }));
+        const prevLock = rootLocks.get(workspace0.root) ?? Promise.resolve();
+        const { promise: turn, resolve: releaseTurn } = Promise.withResolvers<void>();
+        rootLocks.set(
+          workspace0.root,
+          prevLock.then(() => turn),
+        );
+        await prevLock.catch(() => {});
+        let deliverResult: Awaited<ReturnType<typeof deliverInput>>;
+        try {
+          deliverResult = await deliverInput(run, claimed, stage);
+        } finally {
+          releaseTurn();
+          if (rootLocks.get(workspace0.root) === turn) rootLocks.delete(workspace0.root);
+        }
+        const { outcome, segment, drain } = deliverResult;
         if (outcome) {
           stage.name = "settle_outcome";
           debugLog("agent-run", `outcome runId=${runId} status=${outcome.status}`);

--- a/apps/backend/src/features/agent/adapter-sqlite.test.ts
+++ b/apps/backend/src/features/agent/adapter-sqlite.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { openDb } from "../../infra/sqlite/db.js";
 import { sqliteAgentAdapter } from "./adapter-sqlite.js";
-import { agentConfigSchema, buildAgentConfig, serializeAgentYaml } from "./agent-config.js";
+import { buildAgentConfig, serializeAgentYaml } from "./agent-config.js";
 
 const db = openDb(":memory:");
 const adapter = sqliteAgentAdapter(db);

--- a/apps/backend/src/features/agent/adapter-sqlite.test.ts
+++ b/apps/backend/src/features/agent/adapter-sqlite.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { openDb } from "../../infra/sqlite/db.js";
 import { sqliteAgentAdapter } from "./adapter-sqlite.js";
-import { buildAgentConfig } from "./agent-config.js";
+import { agentConfigSchema, buildAgentConfig, serializeAgentYaml } from "./agent-config.js";
 
 const db = openDb(":memory:");
 const adapter = sqliteAgentAdapter(db);
@@ -74,5 +74,21 @@ describe("sqliteAgentAdapter", () => {
     });
     expect(updated).not.toBeNull();
     expect(updated?.config.lark.profile_ref).toBe("agent:a1");
+  });
+});
+
+describe("agent config projects field (ADR 0023)", () => {
+  test("round-trips through the serialized agent.yml form", () => {
+    const config = cfg("a-projects", "ProjAgent", { projects: ["p1", "p2"] });
+    expect(config.runtime_config.projects).toEqual(["p1", "p2"]);
+    const yaml = serializeAgentYaml(config);
+    expect(yaml).toContain("  projects:");
+    expect(yaml).toContain('- "p1"');
+  });
+
+  test("prev fallback keeps existing projects when patch omits them", () => {
+    const prev = cfg("a-prev", "Prev", { projects: ["p1"] });
+    const next = buildAgentConfig({ id: "a-prev", name: "Prev", prev });
+    expect(next.runtime_config.projects).toEqual(["p1"]);
   });
 });

--- a/apps/backend/src/features/agent/agent-compose.ts
+++ b/apps/backend/src/features/agent/agent-compose.ts
@@ -21,7 +21,7 @@ export function createAgentSvc(
   opts?: {
     onAgentCreate?: (agentId: string) => Promise<void>;
     /** Called after agent update (workspace-bridge reconcile). */
-    onAgentUpdate?: (agentId: string) => Promise<void>;
+    onAgentUpdate?: (agentId: string, prevProjects: string[]) => Promise<void>;
     /** Throws when the agent has an active Agent Run. Defaults to no-op. */
     assertNoActiveRun?: (agentId: string) => void;
   },

--- a/apps/backend/src/features/agent/agent-config.ts
+++ b/apps/backend/src/features/agent/agent-config.ts
@@ -23,6 +23,8 @@ export const agentConfigSchema = z.object({
       .array(z.object({ server_id: z.string().min(1), enabled: z.boolean() }))
       .default([]),
     knowledge_packs: z.array(z.string()).default([]),
+    /** Attached projects (ADR 0023): each materializes a worktree. */
+    projects: z.array(z.string().min(1)).default([]),
   }),
   lark: z.object({
     enabled: z.boolean(),
@@ -47,6 +49,7 @@ export function buildAgentConfig(input: {
   maxSteps?: number;
   mcpServers?: Array<{ serverId: string; enabled: boolean }>;
   knowledgePacks?: string[];
+  projects?: string[];
   lark?: {
     enabled?: boolean;
     appId?: string;
@@ -80,6 +83,7 @@ export function buildAgentConfig(input: {
         prev?.runtime_config.mcp_servers ??
         [],
       knowledge_packs: input.knowledgePacks ?? prev?.runtime_config.knowledge_packs ?? [],
+      projects: input.projects ?? prev?.runtime_config.projects ?? [],
     },
     lark: {
       enabled: input.lark?.enabled ?? prev?.lark.enabled ?? false,
@@ -115,6 +119,8 @@ export function serializeAgentYaml(config: AgentConfig): string {
     ...rc.mcp_servers.map((s) => `    - server_id: ${q(s.server_id)}\n      enabled: ${s.enabled}`),
     "  knowledge_packs:",
     ...rc.knowledge_packs.map((p) => `    - ${q(p)}`),
+    "  projects:",
+    ...rc.projects.map((p) => `    - ${q(p)}`),
     "lark:",
     `  enabled: ${lk.enabled}`,
     `  app_id: ${q(lk.app_id)}`,

--- a/apps/backend/src/features/agent/domain.ts
+++ b/apps/backend/src/features/agent/domain.ts
@@ -46,6 +46,7 @@ export interface UpdateAgentInput {
   maxSteps?: number;
   mcpServers?: Array<{ serverId: string; enabled: boolean }>;
   knowledgePacks?: string[];
+  projects?: string[];
   lark?: {
     enabled?: boolean;
     appId?: string;

--- a/apps/backend/src/features/agent/http.ts
+++ b/apps/backend/src/features/agent/http.ts
@@ -33,6 +33,7 @@ function toAgentResponse(row: AgentRow, status: string) {
     maxSteps: rc.max_steps > 0 ? rc.max_steps : null,
     mcpServers: rc.mcp_servers.map((s) => ({ serverId: s.server_id, enabled: s.enabled })),
     knowledgePacks: rc.knowledge_packs,
+    projects: rc.projects,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     archivedAt: row.archivedAt,
@@ -80,6 +81,8 @@ export function agentRoutes(
   identityStore?: AgentIdentityStore,
   larkStatusOf?: (agentId: string) => string,
   getSetupManager?: () => LarkSetupManager,
+  /** Project existence check for the PATCH projects validation. */
+  projectExists?: (id: string) => boolean,
 ) {
   const statusOf = (row: AgentRow) => deriveLarkStatus(row, larkStatusOf?.(row.id));
 
@@ -157,6 +160,13 @@ export function agentRoutes(
               );
             }
           }
+          if (body.projects && projectExists) {
+            for (const pid of body.projects) {
+              if (!projectExists(pid)) {
+                return Response.json({ error: `unknown project ${pid}` }, { status: 400 });
+              }
+            }
+          }
           const row = await svc.update(id, body);
           return toAgentResponse(row, statusOf(row));
         } catch (err) {
@@ -193,6 +203,7 @@ export function agentRoutes(
             t.Array(t.Object({ serverId: t.String({ minLength: 1 }), enabled: t.Boolean() })),
           ),
           knowledgePacks: t.Optional(t.Array(t.String({ minLength: 1 }))),
+          projects: t.Optional(t.Array(t.String({ minLength: 1 }))),
           lark: t.Optional(
             t.Object({
               enabled: t.Optional(t.Boolean()),

--- a/apps/backend/src/features/agent/service.ts
+++ b/apps/backend/src/features/agent/service.ts
@@ -32,7 +32,7 @@ export function createAgentService(opts: {
   /** Optional hook called after agent creation (e.g. assign builtin skill pack). */
   onCreate?: (agentId: string) => Promise<void>;
   /** Optional hook called after agent update (e.g. workspace-bridge reconcile). */
-  onUpdate?: (agentId: string) => Promise<void>;
+  onUpdate?: (agentId: string, prevProjects: string[]) => Promise<void>;
   /** Absolute roots an HTTP workspace override may live under (D4: the
    *  workspaceRoot + the managed agents dir). Outside = ValidationError. */
   allowedWorkspaceRoots?: readonly string[];
@@ -142,7 +142,7 @@ export function createAgentService(opts: {
         ...(workspacePath !== existing.workspacePath ? { workspacePath } : {}),
       });
       if (!row) throw new AgentNotFoundError(id);
-      await onUpdate?.(id);
+      await onUpdate?.(id, existing.config.runtime_config.projects);
       return row;
     },
 

--- a/apps/backend/src/features/agent/service.ts
+++ b/apps/backend/src/features/agent/service.ts
@@ -117,6 +117,7 @@ export function createAgentService(opts: {
         maxSteps: input.maxSteps,
         mcpServers: input.mcpServers,
         knowledgePacks: input.knowledgePacks,
+        projects: input.projects,
         lark: input.lark
           ? {
               enabled: input.lark.enabled,

--- a/apps/backend/src/features/agent/workspace-bridge.test.ts
+++ b/apps/backend/src/features/agent/workspace-bridge.test.ts
@@ -10,7 +10,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { reconcileSkillLinks, writeMcpConfig } from "./workspace-bridge.js";
+import {
+  reconcileAgentResources,
+  reconcileSkillLinks,
+  writeMcpConfig,
+} from "./workspace-bridge.js";
 
 function tmpWorkspace(): string {
   const dir = mkdtempSync(join(tmpdir(), "bridge-"));
@@ -67,5 +71,30 @@ describe("workspace bridge", () => {
     writeMcpConfig(ws, []);
     expect(existsSync(path)).toBe(false);
     rmSync(ws, { recursive: true, force: true });
+  });
+});
+
+describe("extraRoots bridge (ADR 0023)", () => {
+  test("mcp + product tools bridge into worktree roots too", () => {
+    const ws = tmpWorkspace();
+    const wt = tmpWorkspace();
+    reconcileAgentResources({
+      workspacePath: ws,
+      kind: "coding_agent",
+      skillPacks: [],
+      mcpServers: [
+        {
+          name: "product-tools",
+          transport: "sse",
+          url: "http://127.0.0.1:3005/sse",
+          bearerTokenEnv: "PRODUCT_TOOLS_RUN_TOKEN",
+        },
+      ],
+      productTools: [{ name: "history_recent" }],
+      knowledgePacks: [],
+      extraRoots: [wt],
+    });
+    expect(existsSync(join(wt, ".mcp.json"))).toBe(true);
+    expect(existsSync(join(wt, ".agent", "product-tools.json"))).toBe(true);
   });
 });

--- a/apps/backend/src/features/agent/workspace-bridge.ts
+++ b/apps/backend/src/features/agent/workspace-bridge.ts
@@ -143,6 +143,7 @@ export function writeProductToolsManifest(
     }
     return;
   }
+  mkdirSync(join(workspacePath, ".agent"), { recursive: true });
   writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
@@ -227,10 +228,15 @@ export function reconcileAgentResources(input: {
     name: string;
     description: string;
   }>;
+  /** Extra workspace roots (project worktrees, ADR 0023) receiving the
+   *  same mcp + product-tools bridge. The caller materializes them. */
+  extraRoots?: readonly string[];
 }): void {
+  for (const root of [input.workspacePath, ...(input.extraRoots ?? [])]) {
+    writeMcpConfig(root, input.mcpServers);
+    writeProductToolsManifest(root, input.productTools);
+  }
   reconcileSkillLinks(input.workspacePath, input.kind, input.skillPacks);
-  writeMcpConfig(input.workspacePath, input.mcpServers);
-  writeProductToolsManifest(input.workspacePath, input.productTools);
   reconcileKnowledgeResources(input.workspacePath, input.knowledgePacks);
   writeClaudeSettings(input.workspacePath);
 }

--- a/apps/backend/src/features/conversation/adapter-sqlite.ts
+++ b/apps/backend/src/features/conversation/adapter-sqlite.ts
@@ -56,6 +56,7 @@ export function sqliteConversationAdapter(db: Database): ConversationPort {
           createdAt: input.createdAt,
           forkSource: input.forkSource ?? null,
           forkFromSeq: input.forkFromSeq ?? null,
+          projectId: input.projectId ?? null,
         })
         .returning()
         .get();

--- a/apps/backend/src/features/conversation/http.ts
+++ b/apps/backend/src/features/conversation/http.ts
@@ -9,6 +9,7 @@ export function conversationRoutes(
   svc: ConversationService,
   idGen: () => string,
   goalStore: GoalStateStore,
+  projectExists?: (id: string) => boolean,
 ) {
   return (
     new Elysia()
@@ -23,10 +24,14 @@ export function conversationRoutes(
         async ({ body, set }) => {
           const conversationId = body.conversationId ?? idGen();
           const now = Date.now();
+          if (body.projectId && projectExists && !projectExists(body.projectId)) {
+            return Response.json({ error: `unknown project ${body.projectId}` }, { status: 400 });
+          }
           svc.port.createConversation({
             conversationId,
             triggerMode: body.triggerMode ?? "mention",
             createdAt: now,
+            projectId: body.projectId ?? null,
           });
           const members = body.members ?? [];
           for (const m of members) {
@@ -46,6 +51,7 @@ export function conversationRoutes(
         {
           body: t.Object({
             conversationId: t.Optional(t.String({ minLength: 1 })),
+            projectId: t.Optional(t.String({ minLength: 1 })),
             members: t.Optional(
               t.Array(
                 t.Object({
@@ -85,6 +91,7 @@ export function conversationRoutes(
           title: conv.title,
           createdAt: conv.createdAt,
           forkSource: conv.forkSource,
+          projectId: conv.projectId,
           forkFromSeq: conv.forkFromSeq,
           lastActivityAt: svc.port.getLastActivityAt?.(id) ?? null,
           lastMessagePreview: svc.port.getLastMessagePreview?.(id) ?? null,

--- a/apps/backend/src/features/conversation/ports.ts
+++ b/apps/backend/src/features/conversation/ports.ts
@@ -15,6 +15,8 @@ export interface ConversationRow {
   forkSource: string | null;
   /** Fork provenance: source ledger seq the fork was cut from, else null. */
   forkFromSeq: number | null;
+  /** Project binding (ADR 0023): runs use the project worktree as cwd. */
+  projectId: string | null;
 }
 
 export interface MemberRow {
@@ -41,6 +43,7 @@ export interface CreateConversationInput {
   forkSource?: string | null;
   /** Fork provenance: source ledger seq the fork was cut from. */
   forkFromSeq?: number | null;
+  projectId?: string | null;
 }
 
 export interface CreateMemberInput {

--- a/apps/backend/src/features/cron/scheduler.ts
+++ b/apps/backend/src/features/cron/scheduler.ts
@@ -36,6 +36,8 @@ export function createCronScheduler(deps: {
   cronSvc: CronJobService;
   config: BackendConfig;
   convPort: ConversationPort;
+  /** Resolve LOOP.md agent ids to workspace paths (ADR 0023 P2). */
+  agentWorkspaceOf: (agentId: string) => Promise<string | null>;
   agentRunService: AgentRunService;
   agentRunExecution: AgentRunExecutionService;
   resolveDefaultModel: (agentId: string) => Promise<BackendModelRef>;
@@ -165,6 +167,7 @@ export function createCronScheduler(deps: {
         modelId,
       }),
       builtinSkillsDir: deps.config.builtinSkillsDir,
+      agentWorkspaceOf: deps.agentWorkspaceOf,
     };
     let attempt = 0;
     let currentJob = job;

--- a/apps/backend/src/features/loop/http.test.ts
+++ b/apps/backend/src/features/loop/http.test.ts
@@ -78,6 +78,7 @@ function makeApp(activeRuns = false) {
         } as never,
         agentRunExecution: {} as never,
         resolveModel: async () => ({ kind: "anthropic", id: "test" }) as never,
+        agentWorkspaceOf: async () => null,
       }),
     );
 

--- a/apps/backend/src/features/loop/http.ts
+++ b/apps/backend/src/features/loop/http.ts
@@ -82,6 +82,7 @@ export function loopRoutes(input: {
             name: body.name,
             intent: body.intent,
             projectId: body.projectId,
+            agent: body.agent,
             cronExpr: body.cronExpr,
           },
         );
@@ -93,6 +94,7 @@ export function loopRoutes(input: {
           name: t.String(),
           intent: t.Optional(t.String()),
           projectId: t.Optional(t.String()),
+          agent: t.Optional(t.String({ minLength: 1 })),
           cronExpr: t.Optional(t.String()),
         }),
       },

--- a/apps/backend/src/features/loop/http.ts
+++ b/apps/backend/src/features/loop/http.ts
@@ -34,6 +34,7 @@ export function loopRoutes(input: {
   agentRunExecution: AgentRunExecutionService;
   resolveModel: (modelName: string) => Promise<BackendModelRef>;
   settingsSvc?: SettingsService;
+  agentWorkspaceOf: (agentId: string) => Promise<string | null>;
 }) {
   const {
     cronSvc,
@@ -46,10 +47,12 @@ export function loopRoutes(input: {
     agentRunExecution,
     resolveModel,
     settingsSvc,
+    agentWorkspaceOf,
   } = input;
 
   const loopStepDeps = {
     dataDir,
+    agentWorkspaceOf,
     store,
     projectPort,
     convPort,

--- a/apps/backend/src/features/loop/http.ts
+++ b/apps/backend/src/features/loop/http.ts
@@ -63,7 +63,7 @@ export function loopRoutes(input: {
 
   return new Elysia()
     .get("/api/loops", () => {
-      return { loops: listLoops(cronSvc, store) };
+      return { loops: listLoops(cronSvc, store, dataDir) };
     })
     .get("/api/work/today", () => {
       return { reviewQueue: getTodayWork(cronSvc, store) };

--- a/apps/backend/src/features/loop/loop-service.ts
+++ b/apps/backend/src/features/loop/loop-service.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 import type { BackendModelRef } from "@my-agent-team/agent-backend";
 import type { ItemState, LoopState, Verdict } from "@my-agent-team/loop";
@@ -6,10 +7,10 @@ import type { AgentRunService } from "../agent-run/service.js";
 import type { ConversationPort } from "../conversation/ports.js";
 import type { CronJobService } from "../cron/service.js";
 import { loopStep } from "../loop/loop-step.js";
-import { resolveLoopPaths } from "../loop/resolve-paths.js";
 import type { ProjectPort } from "../project/ports.js";
 import type { SettingsService } from "../settings/index.js";
 import type { LoopStateStore } from "./loop-state-store.js";
+import { resolveLoopPaths } from "./resolve-paths.js";
 
 // ── Result types ───────────────────────────────────────────────────────────
 
@@ -79,13 +80,35 @@ export type RefineLoopResult = {
 
 // ── Query functions ────────────────────────────────────────────────────────
 
-export function listLoops(cronSvc: CronJobService, store: LoopStateStore): LoopListItem[] {
+/** Minimal LOOP.md frontmatter read for list views: projectId + agent. */
+function readLoopProjectId(loopConfigPath: string): string | null {
+  try {
+    const text = readFileSync(`${loopConfigPath}/LOOP.md`, "utf-8");
+    const m = text.match(/^---\s*\n([\s\S]*?)\n---/);
+    if (!m?.[1]) return null;
+    const pid = m[1].match(/^projectId:\s*(.+)$/m);
+    return pid?.[1]?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function listLoops(
+  cronSvc: CronJobService,
+  store: LoopStateStore,
+  dataDir = ".",
+): LoopListItem[] {
   return cronSvc.port.listCronJobs().map((job) => {
     const state = job.loopConfigPath ? store.load(job.cronJobId) : null;
     return {
       cronJobId: job.cronJobId,
       name: job.name,
       agentId: job.agentId,
+      // Project binding from LOOP.md frontmatter (read once per list; the
+      // file parse is cheap and cached by the OS).
+      projectId: job.loopConfigPath
+        ? readLoopProjectId(resolveLoopPaths(job, dataDir).loopConfigPath)
+        : null,
       cronExpr: job.cronExpr,
       enabled: job.enabled,
       loopConfigPath: job.loopConfigPath ?? null,

--- a/apps/backend/src/features/loop/loop-service.ts
+++ b/apps/backend/src/features/loop/loop-service.ts
@@ -278,6 +278,7 @@ export async function runLoop(
     resolveModel: (modelName: string) => Promise<BackendModelRef>;
     /** Repo builtin skills dir; forwarded to the Loop step. */
     builtinSkillsDir?: string;
+    agentWorkspaceOf: (agentId: string) => Promise<string | null>;
   },
   id: string,
 ): Promise<LoopState | null> {
@@ -305,6 +306,7 @@ export async function runLoop(
     agentRunExecution,
     resolveModel,
     ...(deps.builtinSkillsDir ? { builtinSkillsDir: deps.builtinSkillsDir } : {}),
+    agentWorkspaceOf: deps.agentWorkspaceOf,
   });
 }
 
@@ -326,6 +328,7 @@ export async function reviewLoop(
     resolveModel: (modelName: string) => Promise<BackendModelRef>;
     /** Repo builtin skills dir; forwarded to the Loop step. */
     builtinSkillsDir?: string;
+    agentWorkspaceOf: (agentId: string) => Promise<string | null>;
   },
   id: string,
   input: ReviewInput,
@@ -359,6 +362,7 @@ export async function reviewLoop(
     agentRunExecution,
     resolveModel,
     ...(deps.builtinSkillsDir ? { builtinSkillsDir: deps.builtinSkillsDir } : {}),
+    agentWorkspaceOf: deps.agentWorkspaceOf,
   });
 
   return { state, action: input.verdict };

--- a/apps/backend/src/features/loop/loop-service.ts
+++ b/apps/backend/src/features/loop/loop-service.ts
@@ -151,6 +151,7 @@ export interface CreateLoopInput {
   name: string;
   intent?: string;
   projectId?: string;
+  agent?: string;
   cronExpr?: string;
 }
 
@@ -214,7 +215,7 @@ export async function createLoop(
   }
 
   // 4. Deterministic LOOP.md (intent is documented, not interpreted)
-  await writeDefaultLoopMd(dir, input.name, input.projectId, settingsSvc);
+  await writeDefaultLoopMd(dir, input.name, input.projectId, input.agent, settingsSvc);
 
   return readGenerationResult(dir, job.cronJobId, job.name, job.cronExpr, job.loopConfigPath);
 }
@@ -242,7 +243,7 @@ export async function refineLoop(
   const dir = `${dataDir}/${job.loopConfigPath}`;
 
   await safeRm(`${dir}/LOOP.md`);
-  await writeDefaultLoopMd(dir, job.name, undefined, settingsSvc);
+  await writeDefaultLoopMd(dir, job.name, undefined, undefined, settingsSvc);
 
   let preview = "";
   try {
@@ -371,6 +372,7 @@ async function writeDefaultLoopMd(
   dir: string,
   name: string,
   projectId: string | undefined,
+  agent: string | undefined,
   settingsSvc?: SettingsService,
 ): Promise<void> {
   // LOOP.md stores the FULL canonical model ID (<provider>/<model>) - the
@@ -394,6 +396,7 @@ async function writeDefaultLoopMd(
     [
       "---",
       `projectId: ${projectId ?? ""}`,
+      `agent: ${agent ?? "default"}`,
       "generator:",
       `  model: ${genModel}`,
       '  systemPrompt: ""',

--- a/apps/backend/src/features/loop/loop-step.test.ts
+++ b/apps/backend/src/features/loop/loop-step.test.ts
@@ -300,7 +300,13 @@ async function runStep(
   const dataDir = overrides.dataDir ?? ownGit!.dataDir;
   const projectPort = overrides.projectPort ?? ownGit!.projectPort;
   const dir = overrides.dir ?? (await initLoopDir("test-project"));
-  const fake = makeFakeRuns(overrides.script ?? {}, `${dataDir}/repos/test-project`);
+  // The loop step materializes the agent worktree at
+  // <agentWs>/projects/<projectId>; the fake workflow meta write must land
+  // there (the real seed does).
+  const fake = makeFakeRuns(
+    overrides.script ?? {},
+    join(dataDir, "loop-agent-ws", "projects", "test-project"),
+  );
   try {
     const result = await loopStep({
       loopConfigPath: dir,
@@ -322,6 +328,7 @@ async function runStep(
       agentRunService: fake.agentRunService,
       agentRunExecution: fake.agentRunExecution,
       resolveModel: async (name) => ({ backendKind: "coding_agent", modelId: name }),
+      agentWorkspaceOf: async () => join(dataDir, "loop-agent-ws"),
     });
     return { result, ...fake };
   } finally {
@@ -399,7 +406,10 @@ describe("loopStep — Generator/Evaluator as Agent Runs", () => {
     try {
       const dir = await initLoopDir("test-project");
       try {
-        const fake = makeFakeRuns({ genStatus: "failed" }, `${dataDir}/repos/test-project`);
+        const fake = makeFakeRuns(
+          { genStatus: "failed" },
+          join(dataDir, "loop-agent-ws", "projects", "test-project"),
+        );
         await expect(
           loopStep({
             loopConfigPath: dir,
@@ -417,6 +427,7 @@ describe("loopStep — Generator/Evaluator as Agent Runs", () => {
             agentRunService: fake.agentRunService,
             agentRunExecution: fake.agentRunExecution,
             resolveModel: async (name) => ({ backendKind: "coding_agent", modelId: name }),
+            agentWorkspaceOf: async () => join(dataDir, "loop-agent-ws"),
           }),
         ).rejects.toThrow("generator run");
         expect(fake.enqueues.some((e) => e.agentMemberId.startsWith("loop-evaluator"))).toBe(false);
@@ -560,7 +571,9 @@ describe("loopStep — Generator/Evaluator as Agent Runs", () => {
         script: {},
       });
       const gen = enqueues.find((e) => e.agentMemberId.startsWith("loop-generator"))!;
-      expect(gen.message.text).toContain(`${dataDir}/repos/test-project`);
+      expect(gen.message.text).toContain(
+        join(dataDir, "loop-agent-ws", "projects", "test-project"),
+      );
       expect(gen.message.text).toContain("Project Context");
       expect(gen.message.text).toContain("Recent changes");
     } finally {

--- a/apps/backend/src/features/loop/loop-step.test.ts
+++ b/apps/backend/src/features/loop/loop-step.test.ts
@@ -93,7 +93,6 @@ async function setupGitDataDir(): Promise<{
         name: "test",
         repoUrl: bareSrc,
         defaultBranch: "main",
-        autoOrchestrate: false,
         createdAt: 0,
         updatedAt: 0,
       };

--- a/apps/backend/src/features/loop/loop-step.ts
+++ b/apps/backend/src/features/loop/loop-step.ts
@@ -1,15 +1,14 @@
-import { existsSync } from "node:fs";
+import { join } from "node:path";
 import type { BackendModelRef, BackendRunOutcome } from "@my-agent-team/agent-backend";
 import type { LoopConfig, LoopState, Verdict } from "@my-agent-team/loop";
-import { ensureMirror, ensureWorktree } from "../project/worktree.js";
 import { loopReducer, parseLoopConfig, validateLoopMetaPatch } from "@my-agent-team/loop";
 import { isTerminalStatus } from "../agent-run/domain.js";
 import type { AgentRunExecutionService } from "../agent-run/execution.js";
 import type { AgentRunService } from "../agent-run/service.js";
 import type { ConversationPort } from "../conversation/ports.js";
 import type { ProjectPort } from "../project/ports.js";
+import { ensureMirror, ensureWorktree } from "../project/worktree.js";
 import type { LoopStateStore } from "./loop-state-store.js";
-import { join } from "node:path";
 
 type ReviewAction = {
   itemId: string;

--- a/apps/backend/src/features/loop/loop-step.ts
+++ b/apps/backend/src/features/loop/loop-step.ts
@@ -271,12 +271,6 @@ export async function loopStep(params: LoopStepParams): Promise<LoopState> {
 }
 
 async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
-  const cwd = await resolveLoopWorktree(params.loopConfigPath, {
-    projectPort: params.projectPort,
-    dataDir: params.dataDir,
-    agentWorkspaceOf: params.agentWorkspaceOf,
-  });
-
   // 1. Read state from DB
   let state = params.store.load(params.loopId);
   // inboxItems stored as items with step="inbox" — separate them
@@ -347,6 +341,15 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
     return state;
   }
 
+  // The worktree is materialized ONLY for the generator path: review
+  // actions early-return above and must never reset a worktree that a
+  // live run may hold (H1 from the landing review).
+  const cwd = await resolveLoopWorktree(params.loopConfigPath, {
+    projectPort: params.projectPort,
+    dataDir: params.dataDir,
+    agentWorkspaceOf: params.agentWorkspaceOf,
+  });
+
   // 3. Cron TICK — Generator → Evaluator
   state = loopReducer(state, { type: "TICK" });
 
@@ -414,7 +417,7 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
     // verdict back into the script's meta via the write tool.
     const genConversationId = loopGeneratorConversationId(params.loopId);
     const genMemberId = loopGeneratorMemberId(params.loopId);
-    await ensureLoopScope(params.convPort, genConversationId, genMemberId, "default");
+    await ensureLoopScope(params.convPort, genConversationId, genMemberId, cfg.agent || "default");
     const gitLog = await Bun.$`git log --oneline -5`
       .cwd(repoCwd)
       .quiet()
@@ -568,6 +571,16 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
     const updatedItem = state.items[item.id];
     if (updatedItem && (updatedItem.step === "fixing" || updatedItem.step === "inbox")) {
       await git.resetHard(repoCwd, baseSha);
+    } else if (verdict.verdict === "PASS" && cwd) {
+      // PASS: commit the approved work onto the agent branch (H2 from the
+      // landing review) — the model is told not to commit, so the product
+      // layer does it. Without this the next step's clean-start reset
+      // would destroy the approved changes and ahead would stay 0.
+      const staged = await Bun.$`git -C ${cwd} status --porcelain`.quiet().text();
+      if (staged.trim()) {
+        await Bun.$`git -C ${cwd} add -A`.quiet();
+        await Bun.$`git -C ${cwd} -c user.email=loop@agent -c user.name=loop commit -qm ${`loop ${params.loopId} item ${item.id}`}`.quiet();
+      }
     }
   }
 

--- a/apps/backend/src/features/loop/loop-step.ts
+++ b/apps/backend/src/features/loop/loop-step.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import type { BackendModelRef, BackendRunOutcome } from "@my-agent-team/agent-backend";
 import type { LoopConfig, LoopState, Verdict } from "@my-agent-team/loop";
+import { ensureMirror, ensureWorktree } from "../project/worktree.js";
 import { loopReducer, parseLoopConfig, validateLoopMetaPatch } from "@my-agent-team/loop";
 import { isTerminalStatus } from "../agent-run/domain.js";
 import type { AgentRunExecutionService } from "../agent-run/execution.js";
@@ -8,6 +9,7 @@ import type { AgentRunService } from "../agent-run/service.js";
 import type { ConversationPort } from "../conversation/ports.js";
 import type { ProjectPort } from "../project/ports.js";
 import type { LoopStateStore } from "./loop-state-store.js";
+import { join } from "node:path";
 
 type ReviewAction = {
   itemId: string;
@@ -45,6 +47,9 @@ export interface LoopStepParams {
   /** The repo builtin skills dir (workflow authoring etc.); prepended to
    *  the generator's skill roots when provided. */
   builtinSkillsDir?: string;
+  /** Resolve a LOOP.md agent id to its workspace path (null = unknown
+   *  agent). Wired from the composition root via agentSvc. */
+  agentWorkspaceOf: (agentId: string) => Promise<string | null>;
 }
 
 /** Stable deterministic identities - Generator and Evaluator are fully
@@ -111,14 +116,19 @@ function denylistedFiles(files: string[], patterns: string[]): string[] {
   return files.filter((f) => patterns.some((p) => matchesGlob(f, p)));
 }
 
-/** Resolve (and materialize) the loop's cloned repo workspace. Exported so
- *  the composition root can bind Agent Run workspaces for loop scopes to the
- *  actual clone, not the loop-agent's own workspace. */
-export async function resolveRepoPath(
+/** Resolve the loop agent's (agent, project) worktree and hard-reset it to
+ *  the project's default branch - the per-step clean start (ADR 0023 P2;
+ *  replaces the retired per-step shallow clone). Returns null when the
+ *  loop has no projectId. */
+export async function resolveLoopWorktree(
   loopConfigPath: string,
-  projectPort: ProjectPort | undefined,
-  dataDir: string | undefined,
+  deps: {
+    projectPort: ProjectPort | undefined;
+    dataDir: string | undefined;
+    agentWorkspaceOf: (agentId: string) => Promise<string | null>;
+  },
 ): Promise<string | null> {
+  const { projectPort, dataDir, agentWorkspaceOf } = deps;
   if (!projectPort || !dataDir) return null;
   let cfg: LoopConfig | null;
   try {
@@ -132,20 +142,36 @@ export async function resolveRepoPath(
   if (!project?.repoUrl) {
     throw new Error(`loopStep: project ${projectId} has no repoUrl`);
   }
-  const repoPath = `${dataDir}/repos/${projectId}`;
-  const branch = project.defaultBranch ?? "main";
-  if (!existsSync(repoPath)) {
-    await Bun.$`git clone --depth 1 --branch ${branch} ${project.repoUrl} ${repoPath}`.quiet();
-  } else {
-    await Bun.$`git fetch origin`.cwd(repoPath).quiet();
-    await Bun.$`git checkout ${branch}`.cwd(repoPath).quiet();
-    await Bun.$`git reset --hard origin/${branch}`.cwd(repoPath).quiet();
+  const agentId = cfg?.agent || "default";
+  const agentWs = await agentWorkspaceOf(agentId);
+  if (!agentWs) {
+    throw new Error(`loopStep: LOOP.md agent "${agentId}" not found`);
   }
-  const ok =
-    (await Bun.$`git -C ${repoPath} rev-parse --is-inside-work-tree`.quiet().nothrow()).exitCode ===
-    0;
-  if (!ok) throw new Error(`loopStep: repoPath is not a git work tree: ${repoPath}`);
-  return repoPath;
+  const mirror = await ensureMirror(dataDir, {
+    projectId: project.projectId,
+    repoUrl: project.repoUrl,
+    defaultBranch: project.defaultBranch,
+  });
+  const wt = await ensureWorktree(
+    mirror,
+    agentWs,
+    {
+      projectId: project.projectId,
+      repoUrl: project.repoUrl,
+      defaultBranch: project.defaultBranch,
+    },
+    agentId,
+  );
+  if (!wt) {
+    throw new Error(`loopStep: worktree slot occupied at ${join(agentWs, "projects", projectId)}`);
+  }
+  // Clean start per step: the mirror was just fetched; the default branch
+  // ref there IS the remote tip.
+  const ref = project.defaultBranch
+    ? `refs/heads/${project.defaultBranch}`
+    : "refs/remotes/origin/HEAD";
+  await Bun.$`git -C ${wt} reset --hard ${ref}`.quiet();
+  return wt;
 }
 
 function actionToReducer(action: ReviewAction) {
@@ -246,7 +272,11 @@ export async function loopStep(params: LoopStepParams): Promise<LoopState> {
 }
 
 async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
-  const repoPath = await resolveRepoPath(params.loopConfigPath, params.projectPort, params.dataDir);
+  const cwd = await resolveLoopWorktree(params.loopConfigPath, {
+    projectPort: params.projectPort,
+    dataDir: params.dataDir,
+    agentWorkspaceOf: params.agentWorkspaceOf,
+  });
 
   // 1. Read state from DB
   let state = params.store.load(params.loopId);
@@ -323,16 +353,14 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
 
   const fixingItems = Object.values(state.items).filter((i) => i.step === "fixing");
 
-  // Fail closed: never run git mutations against the backend's own cwd.
-  const gitCwd = repoPath;
-  if (fixingItems.length > 0 && !gitCwd) {
+  // Fail closed: never run git mutations without a resolved worktree.
+  if (fixingItems.length > 0 && !cwd) {
     throw new Error(
-      "loopStep: cannot process fixing items without a resolved repoPath " +
-        "(check LOOP.md projectId, project.repoUrl, and that projectPort/dataDir are wired)",
+      "loopStep: cannot process fixing items without a resolved worktree " +
+        "(check LOOP.md projectId/agent, project.repoUrl, and that projectPort/dataDir are wired)",
     );
   }
-
-  const cwd = gitCwd!;
+  const repoCwd: string = cwd ?? ".";
 
   const git = params.gitRunner ?? {
     revParse: (cwd: string) => Bun.$`git rev-parse HEAD`.cwd(cwd).quiet(),
@@ -379,7 +407,7 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
       break;
     }
 
-    const baseSha = (await git.revParse(cwd)).text().trim();
+    const baseSha = (await git.revParse(repoCwd)).text().trim();
 
     // ── Generator: one Agent Run per item, workflow-driven ──
     // The Loop seeds the workflow script (meta = this item's state); the
@@ -389,13 +417,13 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
     const genMemberId = loopGeneratorMemberId(params.loopId);
     await ensureLoopScope(params.convPort, genConversationId, genMemberId, "default");
     const gitLog = await Bun.$`git log --oneline -5`
-      .cwd(cwd)
+      .cwd(repoCwd)
       .quiet()
       .text()
       .catch(() => "");
-    await Bun.write(`${cwd}/.workflows/loop.js`, seedLoopWorkflowScript(item)).catch(() => {});
+    await Bun.write(`${repoCwd}/.workflows/loop.js`, seedLoopWorkflowScript(item)).catch(() => {});
     const genPromptFull = [
-      buildGeneratorPrompt(item, genPrompt, { repoPath: cwd, gitLog }),
+      buildGeneratorPrompt(item, genPrompt, { repoPath: repoCwd, gitLog }),
       `# Workflow\nThe script at .workflows/loop.js carries this item's state in its meta block. ` +
         `Run it with the workflow_run tool (pass the script text). After the workflow completes, ` +
         `use the write tool to update the meta block in .workflows/loop.js: the item's step must ` +
@@ -422,7 +450,7 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
       skillRoots: genSkillRoots,
       // Workspace is a Run execution fact: the Generator MUST run in the
       // cloned repo, not the loop-agent's own workspace.
-      workspace: { root: cwd, access: "read_write" },
+      workspace: { root: repoCwd, access: "read_write" },
       // Freeze the remaining daily budget on the Run: the child's workflow
       // executor gates subagent spawns against it.
       ...(dailyCap > 0 ? { workflowBudgetTokens: Math.max(0, dailyCap - spent) } : {}),
@@ -450,7 +478,7 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
         idempotencyKey: `loop-gen:${params.loopId}:${item.id}:${baseSha}:retry`,
         systemPrompt: genPrompt || undefined,
         skillRoots: genSkillRoots,
-        workspace: { root: cwd, access: "read_write" },
+        workspace: { root: repoCwd, access: "read_write" },
         ...(dailyCap > 0 ? { workflowBudgetTokens: Math.max(0, dailyCap - spent) } : {}),
       });
       if (retry.acquired && retry.run) {
@@ -476,8 +504,8 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
       );
     }
 
-    const headSha = (await git.revParse(cwd)).text().trim();
-    const filesChanged = (await git.diff(cwd, baseSha, headSha)).text().trim();
+    const headSha = (await git.revParse(repoCwd)).text().trim();
+    const filesChanged = (await git.diff(repoCwd, baseSha, headSha)).text().trim();
 
     state = loopReducer(state, {
       type: "GENERATOR_DONE",
@@ -498,7 +526,7 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
           evidence: "denylist check (pre-verifier)",
         },
       });
-      await git.resetHard(cwd, baseSha);
+      await git.resetHard(repoCwd, baseSha);
       continue;
     }
 
@@ -540,7 +568,7 @@ async function loopStepImpl(params: LoopStepParams): Promise<LoopState> {
     // Rollback on REJECT/ESCALATE
     const updatedItem = state.items[item.id];
     if (updatedItem && (updatedItem.step === "fixing" || updatedItem.step === "inbox")) {
-      await git.resetHard(cwd, baseSha);
+      await git.resetHard(repoCwd, baseSha);
     }
   }
 

--- a/apps/backend/src/features/project/adapter-sqlite.ts
+++ b/apps/backend/src/features/project/adapter-sqlite.ts
@@ -18,8 +18,6 @@ export function sqliteProjectAdapter(db: Database): ProjectPort {
           name: input.name,
           repoUrl: input.repoUrl,
           defaultBranch: input.defaultBranch,
-          autoOrchestrate:
-            input.autoOrchestrate !== undefined ? schema.boolToInt(input.autoOrchestrate) : 0,
           createdAt: input.createdAt,
           updatedAt: input.createdAt,
         })
@@ -48,8 +46,6 @@ export function sqliteProjectAdapter(db: Database): ProjectPort {
       if (patch.name !== undefined) sets.name = patch.name;
       if (patch.repoUrl !== undefined) sets.repoUrl = patch.repoUrl;
       if (patch.defaultBranch !== undefined) sets.defaultBranch = patch.defaultBranch;
-      if (patch.autoOrchestrate !== undefined)
-        sets.autoOrchestrate = schema.boolToInt(patch.autoOrchestrate);
 
       if (Object.keys(sets).length === 0) {
         return this.getProject(projectId);

--- a/apps/backend/src/features/project/domain.ts
+++ b/apps/backend/src/features/project/domain.ts
@@ -4,7 +4,6 @@ export interface ProjectRow {
   repoUrl: string | null;
   defaultBranch: string | null;
   /** M19: Auto-orchestrate toggle — reactor auto-advances issues when true. */
-  autoOrchestrate: boolean;
   createdAt: number;
   updatedAt: number;
 }
@@ -13,12 +12,10 @@ export interface CreateProjectInput {
   name: string;
   repoUrl?: string | null;
   defaultBranch?: string | null;
-  autoOrchestrate?: boolean;
 }
 
 export interface UpdateProjectInput {
   name?: string;
   repoUrl?: string | null;
   defaultBranch?: string | null;
-  autoOrchestrate?: boolean;
 }

--- a/apps/backend/src/features/project/http.test.ts
+++ b/apps/backend/src/features/project/http.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Elysia } from "elysia";
+import { openDb } from "../../infra/sqlite/db.js";
+import { sqliteProjectAdapter } from "./adapter-sqlite.js";
+import { projectRoutes } from "./http.js";
+import { createProjectService } from "./service.js";
+import { createWorktreeOps } from "./worktree-ops.js";
+
+const db = openDb(":memory:");
+const svc = createProjectService({
+  port: sqliteProjectAdapter(db),
+  idGen: () => `p-${Math.random().toString(36).slice(2, 10)}`,
+});
+
+describe("project worktree endpoints", () => {
+  test("501 without ops; status/diff/fast-forward with ops over a real repo", async () => {
+    const app501 = new Elysia().use(projectRoutes(svc));
+    const r501 = await app501.handle(new Request("http://localhost/api/projects/p1/worktrees"));
+    expect(r501.status).toBe(501);
+
+    // Real repo through the P1 plumbing.
+    const dir = mkdtempSync(join(tmpdir(), "wops-http-"));
+    try {
+      const src = join(dir, "src");
+      mkdirSync(src, { recursive: true });
+      await Bun.$`git init -b main ${src}`.quiet();
+      await Bun.$`git -C ${src} config user.email t@t`.quiet();
+      await Bun.$`git -C ${src} config user.name t`.quiet();
+      await Bun.$`echo base > ${join(src, "F.txt")}`.quiet();
+      await Bun.$`git -C ${src} add -A`.quiet();
+      await Bun.$`git -C ${src} commit -m base`.quiet();
+      const row = svc.createProject({
+        name: `wt-http-${Date.now()}`,
+        repoUrl: src,
+        defaultBranch: "main",
+      });
+      const ops = createWorktreeOps({
+        dataDir: dir,
+        projectPort: svc.port,
+        listAgentConfigs: async () => [],
+      });
+      const app = new Elysia().use(projectRoutes(svc, ops));
+      const st = await app.handle(
+        new Request(`http://localhost/api/projects/${row.projectId}/worktrees`),
+      );
+      expect(st.status).toBe(200);
+      const body = (await st.json()) as { worktrees: unknown[] };
+      expect(body.worktrees).toEqual([]);
+      // No agents attached -> empty is the happy path; divergence/FF flows
+      // are covered by worktree-ops.test.ts.
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/backend/src/features/project/http.ts
+++ b/apps/backend/src/features/project/http.ts
@@ -1,8 +1,9 @@
 import { Elysia, t } from "elysia";
 import { ConflictError } from "../../infra/domain-errors.js";
 import { ProjectNotFoundError, type ProjectService, ValidationError } from "./service.js";
+import type { WorktreeOps } from "./worktree-ops.js";
 
-export function projectRoutes(svc: ProjectService) {
+export function projectRoutes(svc: ProjectService, worktreeOps?: WorktreeOps) {
   return new Elysia()
     .get("/api/projects", () => ({ projects: svc.list() }))
     .post(
@@ -58,6 +59,68 @@ export function projectRoutes(svc: ProjectService) {
           defaultBranch: t.Optional(t.Union([t.String(), t.Null()])),
         }),
       },
+    )
+    .get("/api/projects/:id/worktrees", async ({ params: { id } }) => {
+      if (!worktreeOps) {
+        return Response.json({ error: "worktree ops unavailable" }, { status: 501 });
+      }
+      try {
+        return { worktrees: await worktreeOps.status(id) };
+      } catch (err) {
+        if (err instanceof ProjectNotFoundError) {
+          return Response.json({ error: err.message }, { status: 404 });
+        }
+        throw err;
+      }
+    })
+    .get("/api/projects/:id/worktrees/:agentId/diff", async ({ params: { id, agentId } }) => {
+      if (!worktreeOps) {
+        return Response.json({ error: "worktree ops unavailable" }, { status: 501 });
+      }
+      try {
+        return { diff: await worktreeOps.diff(id, agentId) };
+      } catch (err) {
+        if (err instanceof ProjectNotFoundError) {
+          return Response.json({ error: err.message }, { status: 404 });
+        }
+        throw err;
+      }
+    })
+    .post(
+      "/api/projects/:id/worktrees/:agentId/fast-forward",
+      async ({ params: { id, agentId }, body }) => {
+        if (!worktreeOps) {
+          return Response.json({ error: "worktree ops unavailable" }, { status: 501 });
+        }
+        try {
+          await worktreeOps.fastForward(id, agentId, { push: body.push === true });
+          return { ok: true };
+        } catch (err) {
+          if (err instanceof ConflictError) {
+            return Response.json({ error: err.message }, { status: 409 });
+          }
+          throw err;
+        }
+      },
+      { body: t.Object({ push: t.Optional(t.Boolean()) }) },
+    )
+    .post(
+      "/api/projects/:id/worktrees/:agentId/merge",
+      async ({ params: { id, agentId }, body }) => {
+        if (!worktreeOps) {
+          return Response.json({ error: "worktree ops unavailable" }, { status: 501 });
+        }
+        try {
+          await worktreeOps.merge(id, agentId, { push: body.push === true });
+          return { ok: true };
+        } catch (err) {
+          if (err instanceof ConflictError) {
+            return Response.json({ error: err.message }, { status: 409 });
+          }
+          throw err;
+        }
+      },
+      { body: t.Object({ push: t.Optional(t.Boolean()) }) },
     )
     .delete("/api/projects/:id", async ({ params: { id }, set }) => {
       try {

--- a/apps/backend/src/features/project/http.ts
+++ b/apps/backend/src/features/project/http.ts
@@ -22,7 +22,6 @@ export function projectRoutes(svc: ProjectService) {
           name: t.String({ minLength: 1 }),
           repoUrl: t.Optional(t.String()),
           defaultBranch: t.Optional(t.String()),
-          autoOrchestrate: t.Optional(t.Boolean()),
         }),
       },
     )
@@ -54,7 +53,6 @@ export function projectRoutes(svc: ProjectService) {
           name: t.Optional(t.String()),
           repoUrl: t.Optional(t.Union([t.String(), t.Null()])),
           defaultBranch: t.Optional(t.Union([t.String(), t.Null()])),
-          autoOrchestrate: t.Optional(t.Boolean()),
         }),
       },
     )

--- a/apps/backend/src/features/project/http.ts
+++ b/apps/backend/src/features/project/http.ts
@@ -1,4 +1,5 @@
 import { Elysia, t } from "elysia";
+import { ConflictError } from "../../infra/domain-errors.js";
 import { ProjectNotFoundError, type ProjectService, ValidationError } from "./service.js";
 
 export function projectRoutes(svc: ProjectService) {
@@ -31,6 +32,8 @@ export function projectRoutes(svc: ProjectService) {
       } catch (err) {
         if (err instanceof ProjectNotFoundError)
           return Response.json({ error: err.message }, { status: 404 });
+        if (err instanceof ConflictError)
+          return Response.json({ error: err.message }, { status: 409 });
         throw err;
       }
     })
@@ -56,9 +59,9 @@ export function projectRoutes(svc: ProjectService) {
         }),
       },
     )
-    .delete("/api/projects/:id", ({ params: { id }, set }) => {
+    .delete("/api/projects/:id", async ({ params: { id }, set }) => {
       try {
-        svc.remove(id);
+        await svc.remove(id);
         set.status = 204;
         return "";
       } catch (err) {

--- a/apps/backend/src/features/project/ports.ts
+++ b/apps/backend/src/features/project/ports.ts
@@ -5,7 +5,6 @@ export interface CreateProjectRecord {
   name: string;
   repoUrl: string | null;
   defaultBranch: string | null;
-  autoOrchestrate?: boolean;
   createdAt: number;
 }
 
@@ -13,7 +12,6 @@ export interface UpdateProjectRecord {
   name?: string;
   repoUrl?: string | null;
   defaultBranch?: string | null;
-  autoOrchestrate?: boolean;
   updatedAt: number;
 }
 

--- a/apps/backend/src/features/project/service.test.ts
+++ b/apps/backend/src/features/project/service.test.ts
@@ -101,14 +101,14 @@ describe("ProjectService", () => {
     expect(() => svc.update(p2.projectId, { name: p1.name })).toThrow(ValidationError);
   });
 
-  test("remove succeeds", () => {
+  test("remove succeeds", async () => {
     const p = svc.createProject({ name: `remove-${Date.now()}` });
-    svc.remove(p.projectId);
+    await svc.remove(p.projectId);
     expect(svc.exists(p.projectId)).toBe(false);
   });
 
-  test("remove throws ProjectNotFoundError for missing", () => {
-    expect(() => svc.remove("nonexistent")).toThrow(ProjectNotFoundError);
+  test("remove throws ProjectNotFoundError for missing", async () => {
+    await expect(svc.remove("nonexistent")).rejects.toThrow(ProjectNotFoundError);
   });
 
   test("port is exposed", () => {

--- a/apps/backend/src/features/project/service.ts
+++ b/apps/backend/src/features/project/service.ts
@@ -1,4 +1,5 @@
 import {
+  ConflictError,
   ValidationError as DomainValidationError,
   NotFoundError,
 } from "../../infra/domain-errors.js";
@@ -18,6 +19,9 @@ export interface ProjectServiceDeps {
   port: ProjectPort;
   idGen: () => string;
   now?: () => number;
+  /** Agent configs for the detach guard (ADR 0023): deleting a project
+   *  that agents still attach to is refused with their ids. */
+  listAgentConfigs?: () => Promise<Array<{ id: string; projects: string[] }>>;
 }
 
 export function createProjectService(deps: ProjectServiceDeps) {
@@ -94,7 +98,14 @@ export function createProjectService(deps: ProjectServiceDeps) {
       }
     },
 
-    remove(id: string): void {
+    async remove(id: string): Promise<void> {
+      const agents = (await deps.listAgentConfigs?.()) ?? [];
+      const attached = agents.filter((a) => a.projects.includes(id));
+      if (attached.length > 0) {
+        throw new ConflictError(
+          `project ${id} is still attached to: ${attached.map((a) => a.id).join(", ")}`,
+        );
+      }
       if (!port.deleteProject(id)) throw new ProjectNotFoundError(id);
     },
   };

--- a/apps/backend/src/features/project/service.ts
+++ b/apps/backend/src/features/project/service.ts
@@ -31,7 +31,6 @@ export function createProjectService(deps: ProjectServiceDeps) {
       name: string;
       repoUrl?: string | null;
       defaultBranch?: string | null;
-      autoOrchestrate?: boolean;
     }): ProjectRow {
       const name = input.name.trim();
       if (!name) throw new ValidationError("project name required");
@@ -41,7 +40,6 @@ export function createProjectService(deps: ProjectServiceDeps) {
           name,
           repoUrl: input.repoUrl ?? null,
           defaultBranch: input.defaultBranch ?? null,
-          autoOrchestrate: input.autoOrchestrate,
           createdAt: now(),
         });
       } catch (err) {
@@ -73,7 +71,6 @@ export function createProjectService(deps: ProjectServiceDeps) {
         name?: string;
         repoUrl?: string | null;
         defaultBranch?: string | null;
-        autoOrchestrate?: boolean;
       },
     ): ProjectRow {
       if (patch.name !== undefined && !patch.name.trim()) {
@@ -84,7 +81,6 @@ export function createProjectService(deps: ProjectServiceDeps) {
           name: patch.name?.trim() || undefined,
           repoUrl: patch.repoUrl,
           defaultBranch: patch.defaultBranch,
-          autoOrchestrate: patch.autoOrchestrate,
           updatedAt: now(),
         });
         if (!p) throw new ProjectNotFoundError(id);

--- a/apps/backend/src/features/project/worktree-ops.test.ts
+++ b/apps/backend/src/features/project/worktree-ops.test.ts
@@ -2,10 +2,10 @@ import { afterAll, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ProjectPort } from "./ports.js";
 import type { ProjectRow } from "./domain.js";
-import { createWorktreeOps } from "./worktree-ops.js";
+import type { ProjectPort } from "./ports.js";
 import { ensureMirror, ensureWorktree } from "./worktree.js";
+import { createWorktreeOps } from "./worktree-ops.js";
 
 const dirs: string[] = [];
 afterAll(() => {

--- a/apps/backend/src/features/project/worktree-ops.test.ts
+++ b/apps/backend/src/features/project/worktree-ops.test.ts
@@ -17,6 +17,9 @@ async function makeSource(dir: string): Promise<string> {
   const src = join(dir, "src");
   mkdirSync(src, { recursive: true });
   await Bun.$`git init -b main ${src}`.quiet();
+  // Let this non-bare origin accept pushes to its checked-out branch (a
+  // real remote is bare/hosted; this fixture needs the local loophole).
+  await Bun.$`git -C ${src} config receive.denyCurrentBranch updateInstead`.quiet();
   await Bun.$`git -C ${src} config user.email t@t`.quiet();
   await Bun.$`git -C ${src} config user.name t`.quiet();
   await Bun.$`echo base > ${join(src, "F.txt")}`.quiet();
@@ -95,7 +98,6 @@ describe("worktree ops", () => {
 
     const ops = opsFor(dir, src);
     const st = await ops.status(PID);
-    console.log("DEBUG mirror refs:", await Bun.$`git -C  show-ref`.nothrow().quiet().text());
     expect(st).toHaveLength(1);
     expect(st[0]).toMatchObject({ agentId: "a1", ahead: 1, behind: 0, worktreeReady: true });
 
@@ -143,5 +145,29 @@ describe("worktree ops", () => {
 
     const ops = opsFor(dir, src);
     await expect(ops.merge(PID, "a1", { push: false })).rejects.toThrow(/F\.txt/);
+  }, 20_000);
+});
+
+describe("push semantics (regression: mirror forbids refspec push)", () => {
+  test("fast-forward with push lands on the origin and stays after refresh", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wops-push-"));
+    dirs.push(dir);
+    const { mirror, wt, src } = await setup(dir);
+    await Bun.$`echo work > ${join(wt, "P.txt")}`.quiet();
+    await Bun.$`git -C ${wt} add -A`.quiet();
+    await commit(wt, "p");
+
+    const ops = opsFor(dir, src);
+    await ops.fastForward(PID, "a1", { push: true });
+
+    // Origin actually received the tip.
+    const srcTip = await Bun.$`git -C ${src} rev-parse main`.quiet().text();
+    const mirrorTip = await Bun.$`git -C ${mirror} rev-parse main`.quiet().text();
+    expect(mirrorTip.trim()).toBe(srcTip.trim());
+
+    // A subsequent mirror refresh (ff-only fetch) does NOT regress it.
+    await ops.status(PID);
+    const after = await Bun.$`git -C ${mirror} rev-parse main`.quiet().text();
+    expect(after.trim()).toBe(srcTip.trim());
   }, 20_000);
 });

--- a/apps/backend/src/features/project/worktree-ops.test.ts
+++ b/apps/backend/src/features/project/worktree-ops.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ProjectPort } from "./ports.js";
+import type { ProjectRow } from "./domain.js";
+import { createWorktreeOps } from "./worktree-ops.js";
+import { ensureMirror, ensureWorktree } from "./worktree.js";
+
+const dirs: string[] = [];
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+/** source repo with one base commit on main. */
+async function makeSource(dir: string): Promise<string> {
+  const src = join(dir, "src");
+  mkdirSync(src, { recursive: true });
+  await Bun.$`git init -b main ${src}`.quiet();
+  await Bun.$`git -C ${src} config user.email t@t`.quiet();
+  await Bun.$`git -C ${src} config user.name t`.quiet();
+  await Bun.$`echo base > ${join(src, "F.txt")}`.quiet();
+  await Bun.$`git -C ${src} add -A`.quiet();
+  await Bun.$`git -C ${src} commit -m base`.quiet();
+  return src;
+}
+
+const PID = "pp";
+
+function projectRow(repoUrl: string): ProjectRow {
+  return {
+    projectId: PID,
+    name: "p",
+    repoUrl,
+    defaultBranch: "main",
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function fakeProjectPort(repoUrl: string): ProjectPort {
+  return {
+    createProject: () => {
+      throw new Error("unused");
+    },
+    getProject: (id: string) => (id === PID ? projectRow(repoUrl) : null),
+    listProjects: () => [],
+    updateProject: () => null,
+    deleteProject: () => false,
+  };
+}
+
+/** Materialize mirror + the a1 worktree (P1 plumbing — setup, not under test). */
+async function setup(dir: string): Promise<{ mirror: string; wt: string; src: string }> {
+  const src = await makeSource(dir);
+  const dataDir = join(dir, "data");
+  const agentWs = join(dir, "agent");
+  mkdirSync(agentWs, { recursive: true });
+  const mirror = await ensureMirror(dataDir, {
+    projectId: PID,
+    repoUrl: src,
+    defaultBranch: "main",
+  });
+  const wt = await ensureWorktree(
+    mirror,
+    agentWs,
+    { projectId: PID, repoUrl: src, defaultBranch: "main" },
+    "a1",
+  );
+  if (!wt) throw new Error("worktree setup failed");
+  return { mirror, wt, src };
+}
+
+const commit = (wt: string, msg: string) =>
+  Bun.$`git -C ${wt} -c user.email=t@t -c user.name=t commit -q -m ${msg}`.quiet();
+
+function opsFor(dir: string, src: string) {
+  return createWorktreeOps({
+    dataDir: join(dir, "data"),
+    projectPort: fakeProjectPort(src),
+    listAgentConfigs: async () => [
+      { id: "a1", workspacePath: join(dir, "agent"), projects: [PID] },
+    ],
+  });
+}
+
+describe("worktree ops", () => {
+  test("status counts ahead/behind; diff shows the branch changes; fast-forward zeroes ahead; divergence refused", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wops-"));
+    dirs.push(dir);
+    const { mirror, wt, src } = await setup(dir);
+    await Bun.$`echo work > ${join(wt, "W.txt")}`.quiet();
+    await Bun.$`git -C ${wt} add -A`.quiet();
+    await commit(wt, "w");
+
+    const ops = opsFor(dir, src);
+    const st = await ops.status(PID);
+    console.log("DEBUG mirror refs:", await Bun.$`git -C  show-ref`.nothrow().quiet().text());
+    expect(st).toHaveLength(1);
+    expect(st[0]).toMatchObject({ agentId: "a1", ahead: 1, behind: 0, worktreeReady: true });
+
+    const diff = await ops.diff(PID, "a1");
+    expect(diff).toContain("W.txt");
+
+    await ops.fastForward(PID, "a1", { push: false });
+    const st2 = await ops.status(PID);
+    expect(st2[0]?.ahead).toBe(0);
+
+    // Divergence: advance the base past the agent branch (simulating
+    // another agent's merge landing first) plus a new agent commit —
+    // merge-base no longer equals the base tip.
+    await Bun.$`git -C ${mirror} branch other main`.quiet();
+    const otherWt = join(dir, "other-wt");
+    await Bun.$`git -C ${mirror} worktree add -q ${otherWt} other`.quiet();
+    await Bun.$`echo other > ${join(otherWt, "O.txt")}`.quiet();
+    await Bun.$`git -C ${otherWt} add -A`.quiet();
+    await commit(otherWt, "o");
+    await Bun.$`git -C ${mirror} branch -f main other`.quiet();
+    await Bun.$`echo w2 > ${join(wt, "H.txt")}`.quiet();
+    await Bun.$`git -C ${wt} add -A`.quiet();
+    await commit(wt, "w2");
+    await expect(ops.fastForward(PID, "a1", { push: false })).rejects.toThrow(/diverged/);
+    await expect(ops.merge(PID, "a1", { push: false })).rejects.toThrow(/diverged/);
+  }, 20_000);
+
+  test("merge with conflicting changes reports the conflict files", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wops2-"));
+    dirs.push(dir);
+    const { mirror, wt, src } = await setup(dir);
+    // Agent edits F.txt; main also edits F.txt -> conflict.
+    await Bun.$`echo agent > ${join(wt, "F.txt")}`.quiet();
+    await Bun.$`git -C ${wt} add -A`.quiet();
+    await commit(wt, "a");
+    // The base itself (not just the remote) carries the conflicting edit:
+    // advance main in the mirror, as another agent's merge would.
+    await Bun.$`git -C ${mirror} branch other main`.quiet();
+    const otherWt = join(dir, "other-wt");
+    await Bun.$`git -C ${mirror} worktree add -q ${otherWt} other`.quiet();
+    await Bun.$`echo main > ${join(otherWt, "F.txt")}`.quiet();
+    await Bun.$`git -C ${otherWt} add -A`.quiet();
+    await commit(otherWt, "m");
+    await Bun.$`git -C ${mirror} branch -f main other`.quiet();
+
+    const ops = opsFor(dir, src);
+    await expect(ops.merge(PID, "a1", { push: false })).rejects.toThrow(/F\.txt/);
+  }, 20_000);
+});

--- a/apps/backend/src/features/project/worktree-ops.ts
+++ b/apps/backend/src/features/project/worktree-ops.ts
@@ -1,0 +1,157 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { ConflictError } from "../../infra/domain-errors.js";
+import type { ProjectPort } from "./ports.js";
+import { ensureMirror } from "./worktree.js";
+
+export interface WorktreeStatus {
+  agentId: string;
+  branch: string;
+  ahead: number;
+  behind: number;
+  worktreeReady: boolean;
+}
+
+export interface WorktreeOps {
+  status(projectId: string): Promise<WorktreeStatus[]>;
+  diff(projectId: string, agentId: string): Promise<string>;
+  fastForward(projectId: string, agentId: string, opts: { push: boolean }): Promise<void>;
+  merge(projectId: string, agentId: string, opts: { push: boolean }): Promise<void>;
+}
+
+/** Read/merge operations over a project's agent worktrees. All git runs in
+ *  the bare mirror (plumbing) — never in a live worktree (a run may hold
+ *  it). Base moves are branch -f only; two-sided merges are refused (the
+ *  spec's honest boundary: single-branch-ahead only). */
+export function createWorktreeOps(deps: {
+  dataDir: string;
+  projectPort: ProjectPort;
+  listAgentConfigs: () => Promise<Array<{ id: string; workspacePath: string; projects: string[] }>>;
+}): WorktreeOps {
+  const projectOf = (projectId: string) => {
+    const project = deps.projectPort.getProject(projectId);
+    if (!project?.repoUrl) throw new Error(`project ${projectId} has no repoUrl`);
+    return project;
+  };
+
+  const mirrorOf = async (projectId: string): Promise<string> => {
+    const project = projectOf(projectId);
+    return ensureMirror(deps.dataDir, {
+      projectId: project.projectId,
+      repoUrl: project.repoUrl as string,
+      defaultBranch: project.defaultBranch,
+    });
+  };
+
+  const baseRef = (projectId: string): string =>
+    projectOf(projectId).defaultBranch ?? "origin/HEAD";
+
+  /** rev-list counts [behind ahead] between base and the agent branch. */
+  const counts = async (mirror: string, base: string, branch: string) => {
+    const out = await Bun.$`git -C ${mirror} rev-list --left-right --count ${base}...${branch}`
+      .quiet()
+      .nothrow()
+      .text();
+    const [behind, ahead] = out.trim().split(/\s+/).map(Number);
+    return { behind: behind ?? 0, ahead: ahead ?? 0 };
+  };
+
+  const pushBase = async (mirror: string, base: string): Promise<void> => {
+    const res = await Bun.$`git -C ${mirror} push origin ${base}`.quiet().nothrow();
+    if (res.exitCode !== 0) {
+      throw new Error(`push failed: ${res.stderr.toString().slice(0, 200)}`);
+    }
+  };
+
+  /** Move base to the branch tip after the divergence preflight. Shared by
+   *  fast-forward and merge (they differ only in the preflight). */
+  const moveBase = async (
+    projectId: string,
+    agentId: string,
+    opts: { push: boolean },
+    preflight: (mirror: string, base: string, branch: string) => Promise<void>,
+  ): Promise<void> => {
+    const mirror = await mirrorOf(projectId);
+    const base = baseRef(projectId);
+    const branch = `agent/${agentId}/${projectId}`;
+    await preflight(mirror, base, branch);
+    await Bun.$`git -C ${mirror} branch -f ${base} ${branch}`.quiet();
+    if (opts.push) await pushBase(mirror, base);
+  };
+
+  return {
+    async status(projectId) {
+      const mirror = await mirrorOf(projectId);
+      const base = baseRef(projectId);
+      const agents = (await deps.listAgentConfigs()).filter((a) => a.projects.includes(projectId));
+      const out: WorktreeStatus[] = [];
+      for (const a of agents) {
+        const branch = `agent/${a.id}/${projectId}`;
+        const has =
+          (await Bun.$`git -C ${mirror} show-ref --verify refs/heads/${branch}`.quiet().nothrow())
+            .exitCode === 0;
+        if (!has) continue;
+        const { behind, ahead } = await counts(mirror, base, branch);
+        out.push({
+          agentId: a.id,
+          branch,
+          ahead,
+          behind,
+          worktreeReady: existsSync(join(a.workspacePath, "projects", projectId)),
+        });
+      }
+      return out;
+    },
+
+    async diff(projectId, agentId) {
+      const mirror = await mirrorOf(projectId);
+      const base = baseRef(projectId);
+      return Bun.$`git -C ${mirror} diff ${base}...agent/${agentId}/${projectId}`.quiet().text();
+    },
+
+    async fastForward(projectId, agentId, opts) {
+      await moveBase(projectId, agentId, opts, async (mirror, base, branch) => {
+        // Diverged = the branches share no single-base ancestry: the merge
+        // base is neither branch tip.
+        const mb = await Bun.$`git -C ${mirror} merge-base ${base} ${branch}`
+          .quiet()
+          .nothrow()
+          .text();
+        const baseTip = await Bun.$`git -C ${mirror} rev-parse ${base}`.quiet().text();
+        if (mb.trim() !== baseTip.trim()) {
+          throw new ConflictError(`fast-forward refused: ${base} diverged from ${branch}`);
+        }
+      });
+    },
+
+    async merge(projectId, agentId, opts) {
+      await moveBase(projectId, agentId, opts, async (mirror, base, branch) => {
+        // merge-tree preflight in the bare mirror (no worktree needed).
+        // Conflict markers AND the "CONFLICT (...)" summary lines arrive on
+        // stderr; the tree oid lands on stdout.
+        const tree = await Bun.$`git -C ${mirror} merge-tree --write-tree ${base} ${branch} 2>&1`
+          .quiet()
+          .nothrow();
+        const text = tree.text();
+        if (tree.exitCode !== 0 || text.includes("<<<<<<<")) {
+          const files = [...text.matchAll(/CONFLICT \([^)]*\): .* in (.+)/g)]
+            .map((m) => m[1])
+            .slice(0, 10);
+          throw new ConflictError(
+            `merge conflicts: ${files.join(", ") || "see merge-tree output"}`,
+          );
+        }
+        const mb = await Bun.$`git -C ${mirror} merge-base ${base} ${branch}`
+          .quiet()
+          .nothrow()
+          .text();
+        const baseTip = await Bun.$`git -C ${mirror} rev-parse ${base}`.quiet().text();
+        if (mb.trim() !== baseTip.trim()) {
+          throw new ConflictError(
+            `diverged; merge both branches manually (base has commits not on ${branch})`,
+          );
+        }
+      });
+    },
+  };
+}

--- a/apps/backend/src/features/project/worktree-ops.ts
+++ b/apps/backend/src/features/project/worktree-ops.ts
@@ -43,8 +43,14 @@ export function createWorktreeOps(deps: {
     });
   };
 
-  const baseRef = (projectId: string): string =>
-    projectOf(projectId).defaultBranch ?? "origin/HEAD";
+  /** Base branch name; null defaultBranch falls back to the remote HEAD
+   *  the mirror recorded at clone time (resolvable as a raw sha). */
+  const baseRef = async (projectId: string, mirror: string): Promise<string> => {
+    const named = projectOf(projectId).defaultBranch;
+    if (named) return named;
+    const head = await Bun.$`git -C ${mirror} symbolic-ref --short HEAD`.nothrow().quiet().text();
+    return head.trim() || "main";
+  };
 
   /** rev-list counts [behind ahead] between base and the agent branch. */
   const counts = async (mirror: string, base: string, branch: string) => {
@@ -56,15 +62,21 @@ export function createWorktreeOps(deps: {
     return { behind: behind ?? 0, ahead: ahead ?? 0 };
   };
 
+  /** Push the base branch. A mirror clone forbids refspec pushes
+   *  (remote.origin.mirror=true) — override the config per-invocation. */
   const pushBase = async (mirror: string, base: string): Promise<void> => {
-    const res = await Bun.$`git -C ${mirror} push origin ${base}`.quiet().nothrow();
+    const res = await Bun.$`git -C ${mirror} -c remote.origin.mirror=false push origin ${base}`
+      .quiet()
+      .nothrow();
     if (res.exitCode !== 0) {
       throw new Error(`push failed: ${res.stderr.toString().slice(0, 200)}`);
     }
   };
 
   /** Move base to the branch tip after the divergence preflight. Shared by
-   *  fast-forward and merge (they differ only in the preflight). */
+   *  fast-forward and merge (they differ only in the preflight). A failed
+   * push rolls the base back to its previous tip (the caller never sees a
+   * half-moved state). */
   const moveBase = async (
     projectId: string,
     agentId: string,
@@ -72,17 +84,25 @@ export function createWorktreeOps(deps: {
     preflight: (mirror: string, base: string, branch: string) => Promise<void>,
   ): Promise<void> => {
     const mirror = await mirrorOf(projectId);
-    const base = baseRef(projectId);
+    const base = await baseRef(projectId, mirror);
     const branch = `agent/${agentId}/${projectId}`;
     await preflight(mirror, base, branch);
+    const prevTip = (await Bun.$`git -C ${mirror} rev-parse ${base}`.quiet().text()).trim();
     await Bun.$`git -C ${mirror} branch -f ${base} ${branch}`.quiet();
-    if (opts.push) await pushBase(mirror, base);
+    if (opts.push) {
+      try {
+        await pushBase(mirror, base);
+      } catch (err) {
+        await Bun.$`git -C ${mirror} branch -f ${base} ${prevTip}`.quiet().nothrow();
+        throw err;
+      }
+    }
   };
 
   return {
     async status(projectId) {
       const mirror = await mirrorOf(projectId);
-      const base = baseRef(projectId);
+      const base = await baseRef(projectId, mirror);
       const agents = (await deps.listAgentConfigs()).filter((a) => a.projects.includes(projectId));
       const out: WorktreeStatus[] = [];
       for (const a of agents) {
@@ -105,7 +125,7 @@ export function createWorktreeOps(deps: {
 
     async diff(projectId, agentId) {
       const mirror = await mirrorOf(projectId);
-      const base = baseRef(projectId);
+      const base = await baseRef(projectId, mirror);
       return Bun.$`git -C ${mirror} diff ${base}...agent/${agentId}/${projectId}`.quiet().text();
     },
 

--- a/apps/backend/src/features/project/worktree.test.ts
+++ b/apps/backend/src/features/project/worktree.test.ts
@@ -66,3 +66,52 @@ describe("project worktree", () => {
     expect(await Bun.$`cat ${join(slot, "KEEP")}`.text()).toContain("mine");
   });
 });
+
+describe("mirror freshness (regression: fetch used to be a no-op)", () => {
+  test("ensureMirror advances the base branch when origin moves", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wt-fresh-"));
+    dirs.push(dir);
+    const src = await makeSourceRepo(dir);
+    const dataDir = join(dir, "data");
+
+    const mirror = await ensureMirror(dataDir, { ...PROJECT, repoUrl: src });
+    const before = await Bun.$`git -C ${mirror} rev-parse main`.quiet().text();
+
+    // Remote advances.
+    await Bun.$`echo more > ${join(src, "MORE.txt")}`.quiet();
+    await Bun.$`git -C ${src} add -A`.quiet();
+    await Bun.$`git -C ${src} -c user.email=t@t -c user.name=t commit -m more`.quiet();
+
+    await ensureMirror(dataDir, { ...PROJECT, repoUrl: src });
+    const after = await Bun.$`git -C ${mirror} rev-parse main`.quiet().text();
+    expect(after.trim()).not.toBe(before.trim());
+  });
+
+  test("agent branches survive the base refresh", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wt-keep-"));
+    dirs.push(dir);
+    const src = await makeSourceRepo(dir);
+    const dataDir = join(dir, "data");
+    const agentWs = join(dir, "agent-ws");
+    mkdirSync(agentWs, { recursive: true });
+
+    const mirror = await ensureMirror(dataDir, { ...PROJECT, repoUrl: src });
+    const wt = await ensureWorktree(mirror, agentWs, { ...PROJECT, repoUrl: src }, "agent-1");
+    await Bun.$`echo w > ${join(wt!, "W")}`.quiet();
+    await Bun.$`git -C ${wt} add -A`.quiet();
+    await Bun.$`git -C ${wt} -c user.email=t@t -c user.name=t commit -qm w`.quiet();
+
+    await Bun.$`echo more > ${join(src, "MORE")}`.quiet();
+    await Bun.$`git -C ${src} add -A`.quiet();
+    await Bun.$`git -C ${src} -c user.email=t@t -c user.name=t commit -qm m`.quiet();
+    await ensureMirror(dataDir, { ...PROJECT, repoUrl: src });
+
+    const has =
+      (
+        await Bun.$`git -C ${mirror} show-ref --verify refs/heads/agent/agent-1/p1`
+          .nothrow()
+          .quiet()
+      ).exitCode === 0;
+    expect(has).toBe(true);
+  });
+});

--- a/apps/backend/src/features/project/worktree.test.ts
+++ b/apps/backend/src/features/project/worktree.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync, existsSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ensureMirror, ensureWorktree, removeWorktree } from "./worktree.js";

--- a/apps/backend/src/features/project/worktree.test.ts
+++ b/apps/backend/src/features/project/worktree.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureMirror, ensureWorktree, removeWorktree } from "./worktree.js";
+
+/** Build a real source repo with one commit on main. */
+async function makeSourceRepo(dir: string): Promise<string> {
+  const src = join(dir, "src-repo");
+  mkdirSync(src, { recursive: true });
+  await Bun.$`git init -b main ${src}`.quiet();
+  await Bun.$`git -C ${src} config user.email t@t`.quiet();
+  await Bun.$`git -C ${src} config user.name t`.quiet();
+  await Bun.$`echo hello > ${join(src, "README.md")}`.quiet();
+  await Bun.$`git -C ${src} add -A`.quiet();
+  await Bun.$`git -C ${src} commit -m init`.quiet();
+  return src;
+}
+
+const dirs: string[] = [];
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+const PROJECT = { projectId: "p1", repoUrl: "", defaultBranch: "main" };
+
+describe("project worktree", () => {
+  test("mirror + worktree materialize idempotently; detach cleans up", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wt-"));
+    dirs.push(dir);
+    const src = await makeSourceRepo(dir);
+    const dataDir = join(dir, "data");
+    const agentWs = join(dir, "agent-ws");
+    mkdirSync(agentWs, { recursive: true });
+
+    const mirror = await ensureMirror(dataDir, { ...PROJECT, repoUrl: src });
+    expect(existsSync(join(mirror, "HEAD"))).toBe(true);
+    // Second run is a fetch, not a re-clone; still fine.
+    await ensureMirror(dataDir, { ...PROJECT, repoUrl: src });
+
+    const wt = await ensureWorktree(mirror, agentWs, { ...PROJECT, repoUrl: src }, "agent-1");
+    expect(wt).not.toBeNull();
+    expect(existsSync(join(wt!, "README.md"))).toBe(true);
+    const branch = await Bun.$`git -C ${wt} rev-parse --abbrev-ref HEAD`.text();
+    expect(branch.trim()).toBe("agent/agent-1/p1");
+    // Idempotent: same path, no error.
+    const wt2 = await ensureWorktree(mirror, agentWs, { ...PROJECT, repoUrl: src }, "agent-1");
+    expect(wt2).toBe(wt);
+
+    await removeWorktree(mirror, agentWs, { ...PROJECT, repoUrl: src }, "agent-1");
+    expect(existsSync(wt!)).toBe(false);
+  });
+
+  test("occupied worktree slot returns null (user dir never clobbered)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wt2-"));
+    dirs.push(dir);
+    const src = await makeSourceRepo(dir);
+    const agentWs = join(dir, "agent-ws");
+    const slot = join(agentWs, "projects", "p1");
+    mkdirSync(slot, { recursive: true });
+    await Bun.$`echo mine > ${join(slot, "KEEP")}`.quiet();
+
+    const mirror = await ensureMirror(join(dir, "data"), { ...PROJECT, repoUrl: src });
+    const wt = await ensureWorktree(mirror, agentWs, { ...PROJECT, repoUrl: src }, "agent-1");
+    expect(wt).toBeNull();
+    expect(await Bun.$`cat ${join(slot, "KEEP")}`.text()).toContain("mine");
+  });
+});

--- a/apps/backend/src/features/project/worktree.ts
+++ b/apps/backend/src/features/project/worktree.ts
@@ -26,16 +26,16 @@ export async function ensureMirror(dataDir: string, project: WorktreeProject): P
   if (existsSync(mirror)) {
     // The mirror's default refspec (+refs/*:refs/*) overwrites LOCAL heads
     // on every fetch: it deletes agent worktree branches the remote lacks
-    // (--prune) and reverts fast-forwarded base branches. Instead fetch
-    // each remote head with ff-only semantics into the local head — the
-    // base advances with the remote but never regresses, and local-only
+    // (--prune) and reverts fast-forwarded base branches. So refresh ONLY
+    // the project's base branch, ff-only, from the remote — the base
+    // advances with the remote but never regresses, and local-only
     // branches (agent worktrees) are untouchable from the fetch path.
-    const heads = (await Bun.$`git -C ${mirror} for-each-ref refs/remotes/origin`.quiet().text())
-      .split("\n")
-      .map((l) => l.replace("refs/remotes/origin/", "").trim())
-      .filter(Boolean);
-    for (const head of heads) {
-      await Bun.$`git -C ${mirror} fetch -q origin ${head}:${head}`.nothrow().quiet();
+    // NOTE: a mirror clone has no refs/remotes/origin/* namespace; the
+    // remote tip is reachable as FETCH_HEAD right after this fetch.
+    if (project.defaultBranch) {
+      await Bun.$`git -C ${mirror} fetch -q origin ${project.defaultBranch}:${project.defaultBranch}`
+        .nothrow()
+        .quiet();
     }
     return mirror;
   }

--- a/apps/backend/src/features/project/worktree.ts
+++ b/apps/backend/src/features/project/worktree.ts
@@ -1,0 +1,78 @@
+import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+/** Project facts the worktree plumbing needs (subset of ProjectRow). */
+export interface WorktreeProject {
+  readonly projectId: string;
+  readonly repoUrl: string;
+  readonly defaultBranch: string | null;
+}
+
+function worktreePath(agentWorkspace: string, projectId: string): string {
+  return join(agentWorkspace, "projects", projectId);
+}
+
+function branchName(agentId: string, projectId: string): string {
+  return `agent/${agentId}/${projectId}`;
+}
+
+/** Ensure the shared bare mirror exists and is fresh (clone --mirror on
+ *  first attach, fetch --prune afterwards). Concurrent-safe: the clone
+ *  writes to `<id>.git.tmp` then renames; a stale tmp is removed first.
+ *  Returns the mirror path. */
+export async function ensureMirror(dataDir: string, project: WorktreeProject): Promise<string> {
+  const mirror = join(dataDir, "projects", `${project.projectId}.git`);
+  const tmp = `${mirror}.tmp`;
+  mkdirSync(join(dataDir, "projects"), { recursive: true });
+  if (existsSync(mirror)) {
+    await Bun.$`git -C ${mirror} fetch --prune origin`.quiet();
+    return mirror;
+  }
+  if (existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
+  await Bun.$`git clone --mirror ${project.repoUrl} ${tmp}`.quiet();
+  renameSync(tmp, mirror);
+  return mirror;
+}
+
+/** Ensure the agent's worktree exists on its own branch
+ *  (`agent/<agentId>/<projectId>`). Returns the worktree path, or null
+ *  when the slot is occupied by a plain directory (user's own files are
+ *  never clobbered). */
+export async function ensureWorktree(
+  mirrorPath: string,
+  agentWorkspace: string,
+  project: WorktreeProject,
+  agentId: string,
+): Promise<string | null> {
+  const wt = worktreePath(agentWorkspace, project.projectId);
+  const listed = await Bun.$`git -C ${mirrorPath} worktree list --porcelain`.text();
+  if (listed.includes(wt)) return wt;
+  if (existsSync(wt)) return null;
+  const branch = branchName(agentId, project.projectId);
+  const hasBranch =
+    (await Bun.$`git -C ${mirrorPath} show-ref --verify refs/heads/${branch}`.quiet().nothrow())
+      .exitCode === 0;
+  const target = project.defaultBranch ?? "HEAD";
+  mkdirSync(join(agentWorkspace, "projects"), { recursive: true });
+  if (hasBranch) {
+    // Branch survived (e.g. worktree dir removed out-of-band): check it out.
+    await Bun.$`git -C ${mirrorPath} worktree add ${wt} ${branch}`.quiet();
+  } else {
+    await Bun.$`git -C ${mirrorPath} worktree add -b ${branch} ${wt} ${target}`.quiet();
+  }
+  return wt;
+}
+
+/** Detach the worktree and delete its branch. */
+export async function removeWorktree(
+  mirrorPath: string,
+  agentWorkspace: string,
+  project: WorktreeProject,
+  agentId: string,
+): Promise<void> {
+  const wt = worktreePath(agentWorkspace, project.projectId);
+  await Bun.$`git -C ${mirrorPath} worktree remove --force ${wt}`.quiet().nothrow();
+  await Bun.$`git -C ${mirrorPath} branch -D ${branchName(agentId, project.projectId)}`
+    .quiet()
+    .nothrow();
+}

--- a/apps/backend/src/features/project/worktree.ts
+++ b/apps/backend/src/features/project/worktree.ts
@@ -23,9 +23,20 @@ function branchName(agentId: string, projectId: string): string {
 export async function ensureMirror(dataDir: string, project: WorktreeProject): Promise<string> {
   const mirror = join(dataDir, "projects", `${project.projectId}.git`);
   const tmp = `${mirror}.tmp`;
-  mkdirSync(join(dataDir, "projects"), { recursive: true });
   if (existsSync(mirror)) {
-    await Bun.$`git -C ${mirror} fetch --prune origin`.quiet();
+    // The mirror's default refspec (+refs/*:refs/*) overwrites LOCAL heads
+    // on every fetch: it deletes agent worktree branches the remote lacks
+    // (--prune) and reverts fast-forwarded base branches. Instead fetch
+    // each remote head with ff-only semantics into the local head — the
+    // base advances with the remote but never regresses, and local-only
+    // branches (agent worktrees) are untouchable from the fetch path.
+    const heads = (await Bun.$`git -C ${mirror} for-each-ref refs/remotes/origin`.quiet().text())
+      .split("\n")
+      .map((l) => l.replace("refs/remotes/origin/", "").trim())
+      .filter(Boolean);
+    for (const head of heads) {
+      await Bun.$`git -C ${mirror} fetch -q origin ${head}:${head}`.nothrow().quiet();
+    }
     return mirror;
   }
   if (existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });

--- a/apps/backend/src/infra/db/schema.ts
+++ b/apps/backend/src/infra/db/schema.ts
@@ -34,6 +34,11 @@ export const conversation = sqliteTable("conversation", {
   createdAt: integer({ mode: "number" }).notNull(),
   forkSource: text("fork_source"),
   forkFromSeq: integer("fork_from_seq"),
+  /** Project binding (ADR 0023): runs in this conversation use the
+   *  project worktree as cwd. Null = agent workspace (default). */
+  projectId: text("project_id").references(() => project.projectId, {
+    onDelete: "restrict",
+  }),
 });
 
 // ─── member ────────────────────────────────────────────────────────
@@ -94,7 +99,6 @@ export const project = sqliteTable(
     name: text().notNull(),
     repoUrl: text(),
     defaultBranch: text(),
-    autoOrchestrate: integer().notNull().default(0),
     createdAt: integer({ mode: "number" }).notNull(),
     updatedAt: integer({ mode: "number" }).notNull(),
   },
@@ -259,9 +263,8 @@ export const conversationLedgerSelectSchema = createSelectSchema(conversationLed
   undone: (s) => s.transform((v: number) => v !== 0),
 });
 
-export const projectSelectSchema = createSelectSchema(project, {
-  autoOrchestrate: (s) => s.transform((v: number) => v !== 0),
-});
+
+export const projectSelectSchema = createSelectSchema(project);
 
 export const cronJobSelectSchema = createSelectSchema(cronJob, {
   enabled: (s) => s.transform((v: number) => v !== 0),

--- a/apps/backend/src/infra/db/schema.ts
+++ b/apps/backend/src/infra/db/schema.ts
@@ -263,7 +263,6 @@ export const conversationLedgerSelectSchema = createSelectSchema(conversationLed
   undone: (s) => s.transform((v: number) => v !== 0),
 });
 
-
 export const projectSelectSchema = createSelectSchema(project);
 
 export const cronJobSelectSchema = createSelectSchema(cronJob, {

--- a/apps/backend/tests/integration/loop-coding-agent.test.ts
+++ b/apps/backend/tests/integration/loop-coding-agent.test.ts
@@ -269,12 +269,19 @@ describe("Loop with a REAL coding-agent child", () => {
     expect(item.evaluatorRunId).toBeFalsy();
     expect(item.result?.verdict).toBe("PASS");
 
-    // ── The generator REALLY modified and committed the clone ──
+    // ── The generator REALLY modified the worktree; on PASS the product
+    //    layer commits everything onto the agent branch (H2) ──
     const clone = join(dataDir, "loop-agent-ws", "projects", "test-project");
-    const log = await Bun.$`git -C ${clone} log --oneline -1`.quiet().text();
+    const log = await Bun.$`git -C ${clone} log --oneline -3`.quiet().text();
     expect(log).toContain("phase5-change");
-    const diff = await Bun.$`git -C ${clone} diff HEAD~1..HEAD --name-only`.quiet().text();
+    expect(log).toContain("loop loop-e2e item item-1");
+    const diff = await Bun.$`git -C ${clone} diff HEAD~2..HEAD --name-only`.quiet().text();
     expect(diff).toContain("changes.txt");
+
+    // H2: the PASS commit landed on the agent branch — the mirror's base
+    // is now behind it (aggregate-page FF becomes available).
+    const branch = await Bun.$`git -C ${clone} rev-parse --abbrev-ref HEAD`.quiet().text();
+    expect(branch.trim()).toMatch(/^agent\//);
 
     // ── The workflow meta really landed in the clone ──
     const metaScript = await Bun.file(join(clone, ".workflows", "loop.js")).text();

--- a/apps/backend/tests/integration/loop-coding-agent.test.ts
+++ b/apps/backend/tests/integration/loop-coding-agent.test.ts
@@ -237,7 +237,6 @@ describe("Loop with a REAL coding-agent child", () => {
               name: "test",
               repoUrl: join(dataDir, "remote.git"),
               defaultBranch: "main",
-              autoOrchestrate: false,
               createdAt: 0,
               updatedAt: 0,
             }
@@ -260,6 +259,7 @@ describe("Loop with a REAL coding-agent child", () => {
         backendKind: "coding_agent",
         modelId,
       }),
+      agentWorkspaceOf: async () => join(dataDir, "loop-agent-ws"),
     });
 
     // ── State machine: generator + evaluator ran, verdict PASS ──
@@ -270,7 +270,7 @@ describe("Loop with a REAL coding-agent child", () => {
     expect(item.result?.verdict).toBe("PASS");
 
     // ── The generator REALLY modified and committed the clone ──
-    const clone = join(dataDir, "repos", "test-project");
+    const clone = join(dataDir, "loop-agent-ws", "projects", "test-project");
     const log = await Bun.$`git -C ${clone} log --oneline -1`.quiet().text();
     expect(log).toContain("phase5-change");
     const diff = await Bun.$`git -C ${clone} diff HEAD~1..HEAD --name-only`.quiet().text();

--- a/apps/web/scripts/ui-audit.ts
+++ b/apps/web/scripts/ui-audit.ts
@@ -281,6 +281,17 @@ const assertions: Assertion[] = [
         if (!m.hasCol) throw new Error("no 760px message column");
       }),
   },
+  {
+    name: "P2-project-detail has a worktree card container",
+    check: async () =>
+      withPage("/team/projects", async (page) => {
+        await loginIfNeeded(page);
+        const first = await page.$("a[href^='/team/projects/']");
+        if (!first) return; // no projects on this box: nothing to audit
+        await first.click();
+        await page.waitForSelector('[data-testid="project-worktrees"]', { timeout: 15_000 });
+      }),
+  },
 ];
 
 let failed = 0;

--- a/apps/web/src/app/(main)/chat/page.tsx
+++ b/apps/web/src/app/(main)/chat/page.tsx
@@ -49,7 +49,12 @@ export default function ChatOverviewPage() {
     queryKey: ["agents"],
     queryFn: () => api.listAgents(),
   });
+  const { data: projects } = useQuery({
+    queryKey: ["projects"],
+    queryFn: () => api.listProjects(),
+  });
   const [agentId, setAgentId] = useState("default");
+  const [projectId, setProjectId] = useState("");
   const selectedAgent = agents?.find((a) => a.id === agentId);
 
   useEffect(() => {
@@ -67,6 +72,7 @@ export default function ChatOverviewPage() {
     if (!input.trim()) return;
     createConv.mutate(
       {
+        ...(projectId ? { projectId } : {}),
         members: [
           {
             memberId: agentId,
@@ -122,6 +128,19 @@ export default function ChatOverviewPage() {
               {(agents ?? []).map((a) => (
                 <option key={a.id} value={a.id}>
                   {a.name}
+                </option>
+              ))}
+            </select>
+            <select
+              value={projectId}
+              onChange={(e) => setProjectId(e.target.value)}
+              className="text-xs border border-(--hairline) rounded-md bg-transparent px-2 py-1 text-(--ink-strong)"
+              aria-label="Project (optional worktree)"
+            >
+              <option value="">No project</option>
+              {(projects?.projects ?? []).map((p) => (
+                <option key={p.projectId} value={p.projectId}>
+                  {p.name}
                 </option>
               ))}
             </select>

--- a/apps/web/src/app/(main)/team/_components/agent-detail.tsx
+++ b/apps/web/src/app/(main)/team/_components/agent-detail.tsx
@@ -19,7 +19,7 @@ import { useAgentSkillPacks } from "@/features/skill-packs/hooks";
 import { overlineClass } from "@/lib/form-styles";
 import { AgentConfigBar } from "./agent-config-bar";
 import { AgentDescriptionCard } from "./agent-description-card";
-import { AgentProjectsPanel } from "./agent-projects-panel.js";
+import { AgentProjectsPanel } from "./agent-projects-panel";
 
 type Tab =
   | "persona"

--- a/apps/web/src/app/(main)/team/_components/agent-detail.tsx
+++ b/apps/web/src/app/(main)/team/_components/agent-detail.tsx
@@ -19,14 +19,24 @@ import { useAgentSkillPacks } from "@/features/skill-packs/hooks";
 import { overlineClass } from "@/lib/form-styles";
 import { AgentConfigBar } from "./agent-config-bar";
 import { AgentDescriptionCard } from "./agent-description-card";
+import { AgentProjectsPanel } from "./agent-projects-panel.js";
 
-type Tab = "persona" | "skills" | "mcp" | "knowledge" | "memory" | "workspace" | "activity";
+type Tab =
+  | "persona"
+  | "skills"
+  | "mcp"
+  | "knowledge"
+  | "projects"
+  | "memory"
+  | "workspace"
+  | "activity";
 
 const TABS: { key: Tab; label: string }[] = [
   { key: "persona", label: "Persona" },
   { key: "skills", label: "Skills" },
   { key: "mcp", label: "MCP" },
   { key: "knowledge", label: "Knowledge" },
+  { key: "projects", label: "Projects" },
   { key: "memory", label: "Memory" },
   { key: "workspace", label: "Workspace" },
   { key: "activity", label: "Activity" },
@@ -98,6 +108,7 @@ export function AgentDetail({ agentId }: { agentId: string }) {
           {tab === "skills" && <AgentSkillsPanel agentId={agentId} />}
           {tab === "mcp" && <McpServerPanel agentId={agentId} />}
           {tab === "knowledge" && <KnowledgePackPanel agentId={agentId} />}
+          {tab === "projects" && <AgentProjectsPanel agent={agent} />}
           {tab === "memory" && <AgentMemoryPanel agentId={agentId} />}
           {tab === "workspace" && <WorkspaceExplorer agentId={agentId} />}
           {tab === "activity" && (

--- a/apps/web/src/app/(main)/team/_components/agent-projects-panel.tsx
+++ b/apps/web/src/app/(main)/team/_components/agent-projects-panel.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { FolderGit2 } from "lucide-react";
+import { toast } from "sonner";
+import { ListRowCard } from "@/components/ui/polish";
+import { type AgentRow, api } from "@/lib/api";
+
+/** Projects tab (ADR 0023): toggle which projects this agent attaches to.
+ *  Attachment materializes a git worktree under the agent workspace. */
+export function AgentProjectsPanel({ agent }: { agent: AgentRow }) {
+  const qc = useQueryClient();
+  const { data } = useQuery({ queryKey: ["projects"], queryFn: () => api.listProjects() });
+  const attached = agent.projects ?? [];
+
+  async function toggle(projectId: string) {
+    const next = attached.includes(projectId)
+      ? attached.filter((p) => p !== projectId)
+      : [...attached, projectId];
+    try {
+      await api.updateAgent(agent.id, { projects: next });
+      await qc.invalidateQueries({ queryKey: ["agent", agent.id] });
+      toast.success(next.includes(projectId) ? "Project attached" : "Project detached");
+    } catch (err) {
+      toast.error("Failed to update projects", {
+        description: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  }
+
+  const projects = data?.projects ?? [];
+  return (
+    <div className="space-y-2" data-testid="agent-projects">
+      {projects.length === 0 ? (
+        <p className="text-sm text-(--mute)" data-testid="empty-state">
+          No projects yet. Create one under Team → Projects.
+        </p>
+      ) : (
+        projects.map((p) => (
+          <ListRowCard
+            key={p.projectId}
+            icon={<FolderGit2 size={16} className="text-(--mute)" />}
+            title={p.name}
+            idChip={p.projectId}
+            desc={p.repoUrl ?? undefined}
+            tag={attached.includes(p.projectId) ? { label: "attached" } : undefined}
+            actions={
+              <button
+                type="button"
+                onClick={() => void toggle(p.projectId)}
+                className={`text-xs px-2 py-1 rounded border transition-colors ${
+                  attached.includes(p.projectId)
+                    ? "border-(--err)/40 text-(--err) hover:bg-(--err)/10"
+                    : "border-(--primary)/40 text-(--primary) hover:bg-(--primary)/10"
+                }`}
+              >
+                {attached.includes(p.projectId) ? "Detach" : "Attach"}
+              </button>
+            }
+          />
+        ))
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(main)/team/projects/[id]/page.tsx
+++ b/apps/web/src/app/(main)/team/projects/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { FolderGit2 } from "lucide-react";
+import Link from "next/link";
 import { useParams } from "next/navigation";
 import { Page, PageBody, PageHeader } from "@/components/page";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -62,9 +63,13 @@ export default function ProjectDetailPage() {
             </p>
           ) : (
             loops.map((l) => (
-              <div key={l.cronJobId} className="text-sm text-(--body)">
+              <Link
+                key={l.cronJobId}
+                href={`/work/${l.cronJobId}`}
+                className="block rounded-lg border border-(--hairline) bg-(--canvas) px-4 py-3 text-sm text-(--body) hover:border-(--primary) transition-colors"
+              >
                 {l.name}
-              </div>
+              </Link>
             ))
           )}
         </section>

--- a/apps/web/src/app/(main)/team/projects/[id]/page.tsx
+++ b/apps/web/src/app/(main)/team/projects/[id]/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { FolderGit2 } from "lucide-react";
+import { useParams } from "next/navigation";
+import { Page, PageBody, PageHeader } from "@/components/page";
+import { EmptyState } from "@/components/ui/empty-state";
+import { api } from "@/lib/api";
+import { WorktreeCard } from "../_components/worktree-card";
+
+/** Project aggregate (ADR 0023 P2): the project's loops and every attached
+ *  agent's worktree with branch status, diff and merge actions. */
+export default function ProjectDetailPage() {
+  const params = useParams<{ id: string }>();
+  const projectId = params.id;
+  const { data: projectRes } = useQuery({
+    queryKey: ["project", projectId],
+    queryFn: () => api.getProject(projectId),
+  });
+  const { data: wtRes } = useQuery({
+    queryKey: ["project-worktrees", projectId],
+    queryFn: () => api.listProjectWorktrees(projectId),
+  });
+  const { data: loopsRes } = useQuery({
+    queryKey: ["loops"],
+    queryFn: () => api.listLoops(),
+  });
+
+  const project = projectRes?.project;
+  const worktrees = wtRes?.worktrees ?? [];
+  const loops = (loopsRes?.loops ?? []).filter(
+    (l) => "projectId" in l && l.projectId === projectId,
+  );
+
+  return (
+    <Page>
+      <PageHeader
+        breadcrumb="Team / Projects"
+        title={project?.name ?? projectId}
+        description={project?.repoUrl ?? undefined}
+      />
+      <PageBody size="reading" className="space-y-8">
+        <section className="space-y-3" data-testid="project-worktrees">
+          <h2 className="text-sm font-medium">Worktrees</h2>
+          {worktrees.length === 0 ? (
+            <div data-testid="empty-state">
+              <EmptyState
+                icon={FolderGit2}
+                title="No attached agents"
+                description="Attach the project on an agent's detail page (Projects tab) to materialize a worktree."
+              />
+            </div>
+          ) : (
+            worktrees.map((w) => <WorktreeCard key={w.agentId} projectId={projectId} row={w} />)
+          )}
+        </section>
+        <section className="space-y-3">
+          <h2 className="text-sm font-medium">Loops</h2>
+          {loops.length === 0 ? (
+            <p className="text-sm text-(--mute)" data-testid="empty-state">
+              No loops reference this project.
+            </p>
+          ) : (
+            loops.map((l) => (
+              <div key={l.cronJobId} className="text-sm text-(--body)">
+                {l.name}
+              </div>
+            ))
+          )}
+        </section>
+      </PageBody>
+    </Page>
+  );
+}

--- a/apps/web/src/app/(main)/team/projects/_components/worktree-card.tsx
+++ b/apps/web/src/app/(main)/team/projects/_components/worktree-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { GitBranch, GitMerge, FastForward } from "lucide-react";
+import { FastForward, GitBranch, GitMerge } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";

--- a/apps/web/src/app/(main)/team/projects/_components/worktree-card.tsx
+++ b/apps/web/src/app/(main)/team/projects/_components/worktree-card.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { GitBranch, GitMerge, FastForward } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { ListRowCard } from "@/components/ui/polish";
+import { api } from "@/lib/api";
+
+export interface WorktreeRow {
+  agentId: string;
+  branch: string;
+  ahead: number;
+  behind: number;
+  worktreeReady: boolean;
+}
+
+/** One agent's worktree card: branch status vs the project base branch,
+ *  expandable diff, in-page fast-forward / merge (ADR 0023 P2). */
+export function WorktreeCard({ projectId, row }: { projectId: string; row: WorktreeRow }) {
+  const qc = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [push, setPush] = useState(false);
+  const { data: diff } = useQuery({
+    queryKey: ["project-worktree-diff", projectId, row.agentId],
+    queryFn: () => api.projectWorktreeDiff(projectId, row.agentId),
+    enabled: open,
+  });
+
+  async function act(kind: "fast-forward" | "merge") {
+    const confirmed = window.confirm(
+      `${kind === "merge" ? "Merge" : "Fast-forward"} ${row.branch} into the base branch` +
+        `${push ? " and push to origin" : ""}?`,
+    );
+    if (!confirmed) return;
+    try {
+      if (kind === "fast-forward") {
+        await api.projectWorktreeFastForward(projectId, row.agentId, push);
+      } else {
+        await api.projectWorktreeMerge(projectId, row.agentId, push);
+      }
+      await qc.invalidateQueries({ queryKey: ["project-worktrees", projectId] });
+      toast.success(kind === "merge" ? "Merged" : "Fast-forwarded");
+    } catch (err) {
+      toast.error(`Failed to ${kind}`, {
+        description: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  }
+
+  return (
+    <div data-testid="worktree-card" className="space-y-2">
+      <ListRowCard
+        icon={<GitBranch size={16} className="text-(--mute)" />}
+        title={row.agentId}
+        idChip={row.branch}
+        desc={row.worktreeReady ? undefined : "worktree not materialized — attach to materialize"}
+        tag={row.ahead > 0 ? { label: `${row.ahead} ahead` } : undefined}
+        actions={
+          <div className="flex items-center gap-2">
+            {row.behind > 0 && <span className="text-xs text-(--warn)">{row.behind} behind</span>}
+            <label className="flex items-center gap-1 text-xs text-(--mute)">
+              <input type="checkbox" checked={push} onChange={(e) => setPush(e.target.checked)} />
+              push
+            </label>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void act("fast-forward")}
+              disabled={row.ahead === 0}
+            >
+              <FastForward size={12} /> FF
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void act("merge")}
+              disabled={row.ahead === 0}
+            >
+              <GitMerge size={12} /> Merge
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => setOpen((v) => !v)}>
+              {open ? "Hide diff" : "Diff"}
+            </Button>
+          </div>
+        }
+      />
+      {open && (
+        <pre className="max-h-96 overflow-auto rounded-lg border border-(--hairline) bg-(--panel) p-3 text-xs leading-relaxed text-(--body)">
+          {(diff?.diff ?? "loading…").split("\n").slice(0, 200).join("\n")}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(main)/team/projects/_components/worktree-card.tsx
+++ b/apps/web/src/app/(main)/team/projects/_components/worktree-card.tsx
@@ -22,6 +22,8 @@ export function WorktreeCard({ projectId, row }: { projectId: string; row: Workt
   const qc = useQueryClient();
   const [open, setOpen] = useState(false);
   const [push, setPush] = useState(false);
+  const { data: agents } = useQuery({ queryKey: ["agents"], queryFn: () => api.listAgents() });
+  const agentName = agents?.find((a) => a.id === row.agentId)?.name ?? row.agentId;
   const { data: diff } = useQuery({
     queryKey: ["project-worktree-diff", projectId, row.agentId],
     queryFn: () => api.projectWorktreeDiff(projectId, row.agentId),
@@ -53,13 +55,13 @@ export function WorktreeCard({ projectId, row }: { projectId: string; row: Workt
     <div data-testid="worktree-card" className="space-y-2">
       <ListRowCard
         icon={<GitBranch size={16} className="text-(--mute)" />}
-        title={row.agentId}
+        title={agentName}
         idChip={row.branch}
         desc={row.worktreeReady ? undefined : "worktree not materialized — attach to materialize"}
-        tag={row.ahead > 0 ? { label: `${row.ahead} ahead` } : undefined}
+        meta={[`ahead ${row.ahead}`, `behind ${row.behind}`]}
+        tag={row.ahead > 0 ? { label: "has changes" } : undefined}
         actions={
           <div className="flex items-center gap-2">
-            {row.behind > 0 && <span className="text-xs text-(--warn)">{row.behind} behind</span>}
             <label className="flex items-center gap-1 text-xs text-(--mute)">
               <input type="checkbox" checked={push} onChange={(e) => setPush(e.target.checked)} />
               push
@@ -69,6 +71,7 @@ export function WorktreeCard({ projectId, row }: { projectId: string; row: Workt
               size="sm"
               onClick={() => void act("fast-forward")}
               disabled={row.ahead === 0}
+              title={row.ahead === 0 ? "Nothing ahead of the base branch" : undefined}
             >
               <FastForward size={12} /> FF
             </Button>
@@ -77,6 +80,7 @@ export function WorktreeCard({ projectId, row }: { projectId: string; row: Workt
               size="sm"
               onClick={() => void act("merge")}
               disabled={row.ahead === 0}
+              title={row.ahead === 0 ? "Nothing ahead of the base branch" : undefined}
             >
               <GitMerge size={12} /> Merge
             </Button>

--- a/apps/web/src/components/ProjectForm.tsx
+++ b/apps/web/src/components/ProjectForm.tsx
@@ -7,7 +7,6 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -32,7 +31,6 @@ const formSchema = z.object({
   name: z.string().trim().min(1, "Project name is required"),
   repoUrl: z.string().trim().optional().default(""),
   defaultBranch: z.string().trim().optional().default(""),
-  autoOrchestrate: z.boolean().default(false),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -53,7 +51,6 @@ export function ProjectForm({ editProject, onSuccess }: ProjectFormProps) {
       name: editProject?.name ?? "",
       repoUrl: editProject?.repoUrl ?? "",
       defaultBranch: editProject?.defaultBranch ?? "",
-      autoOrchestrate: editProject?.autoOrchestrate ?? false,
     },
   });
 
@@ -64,7 +61,6 @@ export function ProjectForm({ editProject, onSuccess }: ProjectFormProps) {
         name: editProject.name,
         repoUrl: editProject.repoUrl ?? "",
         defaultBranch: editProject.defaultBranch ?? "",
-        autoOrchestrate: editProject.autoOrchestrate ?? false,
       });
       setServerError("");
       setOpen(true);
@@ -92,7 +88,6 @@ export function ProjectForm({ editProject, onSuccess }: ProjectFormProps) {
             name: values.name,
             repoUrl: values.repoUrl || null,
             defaultBranch: values.defaultBranch || null,
-            autoOrchestrate: values.autoOrchestrate,
           },
         },
         {
@@ -112,7 +107,6 @@ export function ProjectForm({ editProject, onSuccess }: ProjectFormProps) {
       createMutation.mutate(
         {
           name: values.name,
-          autoOrchestrate: values.autoOrchestrate,
           ...(values.repoUrl ? { repoUrl: values.repoUrl } : {}),
           ...(values.defaultBranch ? { defaultBranch: values.defaultBranch } : {}),
         },
@@ -190,26 +184,6 @@ export function ProjectForm({ editProject, onSuccess }: ProjectFormProps) {
                   <FormControl>
                     <Input {...field} placeholder="main" className={fieldClass} />
                   </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="autoOrchestrate"
-              render={({ field }) => (
-                <FormItem>
-                  <div className="flex items-center gap-2">
-                    <FormControl>
-                      <Checkbox checked={field.value} onCheckedChange={field.onChange} />
-                    </FormControl>
-                    <FormLabel className={overlineClass}>Auto-advance</FormLabel>
-                  </div>
-                  <p className={hintClass}>
-                    When enabled, completed issues advance to the next column automatically; when
-                    disabled every step needs manual approval.
-                  </p>
                   <FormMessage />
                 </FormItem>
               )}

--- a/apps/web/src/components/ProjectList.tsx
+++ b/apps/web/src/components/ProjectList.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useDeleteProject, useProjectList } from "@/features/projects/hooks";
 import type { ProjectRow } from "@/lib/api";
 import { ProjectForm } from "./ProjectForm";
-import Link from "next/link";
 
 export function ProjectList() {
   const [editingProject, setEditingProject] = useState<ProjectRow | null>(null);

--- a/apps/web/src/components/ProjectList.tsx
+++ b/apps/web/src/components/ProjectList.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { useDeleteProject, useProjectList } from "@/features/projects/hooks";
 import type { ProjectRow } from "@/lib/api";
 import { ProjectForm } from "./ProjectForm";
+import Link from "next/link";
 
 export function ProjectList() {
   const [editingProject, setEditingProject] = useState<ProjectRow | null>(null);
@@ -47,10 +48,10 @@ export function ProjectList() {
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {projects.map((project) => (
           <div key={project.projectId} className="relative group">
-            <div
+            <Link
+              href={`/team/projects/${project.projectId}`}
               className="block border border-(--hairline) rounded-lg bg-(--canvas) p-8
-                         "
-              style={{}}
+                         hover:border-(--primary) transition-colors"
             >
               <h3 className="text-xl font-normal text-(--ink-strong) tracking-tight font-sans">
                 {project.name}
@@ -77,7 +78,7 @@ export function ProjectList() {
                   day: "numeric",
                 })}
               </div>
-            </div>
+            </Link>
 
             {/* Edit / Delete controls */}
             <div className="absolute top-3 right-3 flex gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity">

--- a/apps/web/src/components/ui/polish.tsx
+++ b/apps/web/src/components/ui/polish.tsx
@@ -212,10 +212,12 @@ export function ListRowCard({
         {secondaryActions && <div className="mt-2 flex items-center gap-2">{secondaryActions}</div>}
       </div>
       <div className="flex shrink-0 items-center gap-2">
-        <span className="flex items-center gap-1.5 text-(--text-cap) text-(--mute)">
-          <span className="size-1.5 rounded-full" style={{ background: statusDot }} />
-          {statusText}
-        </span>
+        {status && (
+          <span className="flex items-center gap-1.5 text-(--text-cap) text-(--mute)">
+            <span className="size-1.5 rounded-full" style={{ background: statusDot }} />
+            {statusText}
+          </span>
+        )}
         {actions}
       </div>
     </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -24,6 +24,7 @@ export type LarkSetupSession = ApiReturn<typeof api.larkSetup>;
 export type AgentRow = ApiReturn<typeof api.listAgents>[number] & {
   mcpServers?: Array<{ serverId: string; enabled: boolean }>;
   knowledgePacks?: string[];
+  projects?: string[];
 };
 export type AgentRunDetail = ApiReturn<typeof api.getAgentRun>;
 export type AgentRuntimeStatus = ApiReturn<typeof api.getAgentRuntime>;
@@ -82,6 +83,7 @@ export const api = {
     unwrap(client.api.conversations.get({ query: agentId ? { agentId } : undefined })),
   createConversation: (body: {
     conversationId?: string;
+    projectId?: string;
     members: Array<{
       memberId?: string;
       kind: "agent" | "human";

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -140,19 +140,14 @@ export const api = {
   listSurfaces: () => unwrap(client.api.ops.surfaces.get()),
   // Projects
   listProjects: () => unwrap(client.api.projects.get()),
-  createProject: (body: {
-    name: string;
-    repoUrl?: string;
-    defaultBranch?: string;
-    autoOrchestrate?: boolean;
-  }) => unwrap(client.api.projects.post(body)),
+  createProject: (body: { name: string; repoUrl?: string; defaultBranch?: string }) =>
+    unwrap(client.api.projects.post(body)),
   updateProject: (
     id: string,
     body: {
       name?: string;
       repoUrl?: string | null;
       defaultBranch?: string | null;
-      autoOrchestrate?: boolean;
     },
   ) => unwrap(client.api.projects({ id }).patch(body)),
   deleteProject: (id: string) => unwrap(client.api.projects({ id }).delete()),

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -140,6 +140,14 @@ export const api = {
   listSurfaces: () => unwrap(client.api.ops.surfaces.get()),
   // Projects
   listProjects: () => unwrap(client.api.projects.get()),
+  getProject: (id: string) => unwrap(client.api.projects({ id }).get()),
+  listProjectWorktrees: (id: string) => unwrap(client.api.projects({ id }).worktrees.get()),
+  projectWorktreeDiff: (id: string, agentId: string) =>
+    unwrap(client.api.projects({ id }).worktrees({ agentId }).diff.get()),
+  projectWorktreeFastForward: (id: string, agentId: string, push: boolean) =>
+    unwrap(client.api.projects({ id }).worktrees({ agentId })["fast-forward"].post({ push })),
+  projectWorktreeMerge: (id: string, agentId: string, push: boolean) =>
+    unwrap(client.api.projects({ id }).worktrees({ agentId }).merge.post({ push })),
   createProject: (body: { name: string; repoUrl?: string; defaultBranch?: string }) =>
     unwrap(client.api.projects.post(body)),
   updateProject: (

--- a/docs/superpowers/plans/2026-08-14-project-worktree-p1.md
+++ b/docs/superpowers/plans/2026-08-14-project-worktree-p1.md
@@ -1,0 +1,593 @@
+# Project Worktree P1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Agent↔Project many-to-many via git worktrees: agent.yml declares `projects`, reconcile materializes a worktree per (agent, project) with bridged config, and conversations bound to a project run with cwd = worktree while context stays in the agent workspace.
+
+**Architecture:** A new `worktree.ts` in features/project owns git plumbing (mirror + worktree + branch, all idempotent). The agent config schema gains `runtime_config.projects` (file-first, PATCH-validated). Reconcile extends to materialize worktrees and bridge `.mcp.json`/product-tools into them. `resolveWorkspace` maps conversation.projectId → worktree path (explicit failure when not attached). Migration 0032 adds `conversation.project_id` and drops the dead `auto_orchestrate`.
+
+**Tech Stack:** Bun 1.3 + `Bun.$` git shellouts, drizzle SQLite (hand-written migration), zod config schema, Elysia HTTP, bun:test with real git fixtures.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-project-worktree-p1-design.md` · **ADR:** `docs/adr/0023-project-worktree-workspace.md`
+
+**Hard rules from repo/session:**
+- commitlint: scope in parentheses, no CJK, body lines ≤100 chars.
+- No `as unknown as` (test-double boundary exception only); no python/sed to edit source — read+edit.
+- Hand-written migrations: multi-statement files MUST use `--> statement-breakpoint` separators; `when` strictly increasing (0031 = 1786606000000, use a later value).
+- After touching packages' public types: `bun run build --filter=<pkg>` before apps typecheck.
+
+---
+
+## Task 1: `worktree.ts` — git plumbing
+
+**Files:**
+- Create: `apps/backend/src/features/project/worktree.ts`
+- Test: `apps/backend/src/features/project/worktree.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureMirror, ensureWorktree, removeWorktree } from "./worktree.js";
+
+/** Build a real source repo with one commit on main. */
+async function makeSourceRepo(dir: string): Promise<string> {
+  const src = join(dir, "src-repo");
+  mkdirSync(src, { recursive: true });
+  await Bun.$`git init -b main ${src}`.quiet();
+  await Bun.$`git -C ${src} config user.email t@t`.quiet();
+  await Bun.$`git -C ${src} config user.name t`.quiet();
+  await Bun.$`echo hello > ${join(src, "README.md")}`.quiet();
+  await Bun.$`git -C ${src} add -A`.quiet();
+  await Bun.$`git -C ${src} commit -m init`.quiet();
+  return src;
+}
+
+const dirs: string[] = [];
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+const PROJECT = { projectId: "p1", repoUrl: "", defaultBranch: "main" };
+
+describe("project worktree", () => {
+  test("mirror + worktree materialize idempotently; detach cleans up", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wt-"));
+    dirs.push(dir);
+    const src = await makeSourceRepo(dir);
+    const dataDir = join(dir, "data");
+    const agentWs = join(dir, "agent-ws");
+    mkdirSync(agentWs, { recursive: true });
+
+    const mirror = await ensureMirror(dataDir, { ...PROJECT, repoUrl: src });
+    expect(existsSync(join(mirror, "HEAD"))).toBe(true);
+    // Second run is a fetch, not a re-clone; still fine.
+    await ensureMirror(dataDir, { ...PROJECT, repoUrl: src });
+
+    const wt = await ensureWorktree(mirror, agentWs, { ...PROJECT, repoUrl: src }, "agent-1");
+    expect(existsSync(join(wt, "README.md"))).toBe(true);
+    const branch = await Bun.$`git -C ${wt} rev-parse --abbrev-ref HEAD`.text();
+    expect(branch.trim()).toBe("agent/agent-1/p1");
+    // Idempotent: same path, no error.
+    const wt2 = await ensureWorktree(mirror, agentWs, { ...PROJECT, repoUrl: src }, "agent-1");
+    expect(wt2).toBe(wt);
+
+    await removeWorktree(mirror, agentWs, { ...PROJECT, repoUrl: src }, "agent-1");
+    expect(existsSync(wt)).toBe(false);
+  });
+
+  test("occupied worktree slot returns null (user dir never clobbered)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wt2-"));
+    dirs.push(dir);
+    const src = await makeSourceRepo(dir);
+    const agentWs = join(dir, "agent-ws");
+    const slot = join(agentWs, "projects", "p1");
+    mkdirSync(slot, { recursive: true });
+    await Bun.$`echo mine > ${join(slot, "KEEP")}`.quiet();
+
+    const mirror = await ensureMirror(join(dir, "data"), { ...PROJECT, repoUrl: src });
+    const wt = await ensureWorktree(mirror, agentWs, { ...PROJECT, repoUrl: src }, "agent-1");
+    expect(wt).toBeNull();
+    expect(await Bun.$`cat ${join(slot, "KEEP")}`.text()).toContain("mine");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `cd apps/backend && bun test src/features/project/worktree.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+/** Project facts the worktree plumbing needs (subset of ProjectRow). */
+export interface WorktreeProject {
+  readonly projectId: string;
+  readonly repoUrl: string;
+  readonly defaultBranch: string | null;
+}
+
+function worktreePath(agentWorkspace: string, projectId: string): string {
+  return join(agentWorkspace, "projects", projectId);
+}
+
+function branchName(agentId: string, projectId: string): string {
+  return `agent/${agentId}/${projectId}`;
+}
+
+/** Ensure the shared bare mirror exists and is fresh. Clone writes to
+ *  `<id>.git.tmp` then renames; a stale tmp from a crashed clone is
+ *  removed first. Returns the mirror path. */
+export async function ensureMirror(
+  dataDir: string,
+  project: WorktreeProject,
+): Promise<string> {
+  const mirror = join(dataDir, "projects", `${project.projectId}.git`);
+  const tmp = `${mirror}.tmp`;
+  mkdirSync(join(dataDir, "projects"), { recursive: true });
+  if (existsSync(mirror)) {
+    await Bun.$`git -C ${mirror} fetch --prune origin`.quiet();
+    return mirror;
+  }
+  if (existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
+  await Bun.$`git clone --mirror ${project.repoUrl} ${tmp}`.quiet();
+  renameSync(tmp, mirror);
+  return mirror;
+}
+
+/** Ensure the agent's worktree exists on its own branch. Returns the
+ *  worktree path, or null when the slot is occupied by a non-worktree
+ *  directory (user's own files — never clobbered). */
+export async function ensureWorktree(
+  mirrorPath: string,
+  agentWorkspace: string,
+  project: WorktreeProject,
+  agentId: string,
+): Promise<string | null> {
+  const wt = worktreePath(agentWorkspace, project.projectId);
+  const listed = await Bun.$`git -C ${mirrorPath} worktree list --porcelain`.text();
+  if (listed.includes(wt)) return wt;
+  if (existsSync(wt)) return null; // occupied by a plain directory
+  const branch = branchName(agentId, project.projectId);
+  const base = project.defaultBranch ?? `refs/heads/$(git -C ${mirrorPath} symbolic-ref HEAD)`.slice(0, 0) || "HEAD";
+  const hasBranch =
+    (await Bun.$`git -C ${mirrorPath} show-ref --verify refs/heads/${branch}`.quiet().nothrow())
+      .exitCode === 0;
+  const ref = hasBranch ? branch : `-b ${branch}`;
+  const target = project.defaultBranch ?? (hasBranch ? "" : "HEAD");
+  mkdirSync(join(agentWorkspace, "projects"), { recursive: true });
+  await Bun.$`git -C ${mirrorPath} worktree add ${ref} ${wt} ${target}`.quiet();
+  return wt;
+}
+
+/** Detach the worktree and delete its branch. */
+export async function removeWorktree(
+  mirrorPath: string,
+  agentWorkspace: string,
+  project: WorktreeProject,
+  agentId: string,
+): Promise<void> {
+  const wt = worktreePath(agentWorkspace, project.projectId);
+  await Bun.$`git -C ${mirrorPath} worktree remove --force ${wt}`.quiet().nothrow();
+  await Bun.$`git -C ${mirrorPath} branch -D ${branchName(agentId, project.projectId)}`
+    .quiet()
+    .nothrow();
+}
+```
+
+NOTE for the implementer: the `base` line above is deliberately suspicious — clean it up while implementing: the correct logic is
+`const target = project.defaultBranch ?? "HEAD";` and `ref = hasBranch ? branch : `-b ${branch}``, then `worktree add ${ref} ${wt} ${hasBranch ? "" : target}`. Write the final version plainly; do not keep dead code.
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `cd apps/backend && bun test src/features/project/worktree.test.ts`
+Expected: 2 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/features/project/worktree.ts apps/backend/src/features/project/worktree.test.ts
+git commit -m "feat(backend): project worktree git plumbing - mirror + worktree + branch"
+```
+
+---
+
+## Task 2: agent.yml `projects` field
+
+**Files:**
+- Modify: `apps/backend/src/features/agent/agent-config.ts`
+- Modify: `apps/backend/src/features/agent/service.ts` (buildAgentConfig input)
+- Modify: `apps/backend/src/features/agent/http.ts` (PATCH body + response)
+- Test: extend `apps/backend/src/features/agent/agent-config.test.ts` (or agent-identity.test.ts — wherever yaml round-trip lives)
+
+- [ ] **Step 1: Schema + serialize**
+
+In `agent-config.ts`:
+
+1. Schema (after `knowledge_packs`):
+```typescript
+    /** Attached projects (ADR 0023): each materializes a worktree. */
+    projects: z.array(z.string().min(1)).default([]),
+```
+2. `buildAgentConfig` input type gains `projects?: string[];` and the merge:
+```typescript
+      projects: input.projects ?? prev?.runtime_config.projects ?? [],
+```
+3. Serializer (after the knowledge_packs lines, ~line 117):
+```typescript
+    "  projects:",
+    ...rc.projects.map((p) => `    - ${q(p)}`),
+```
+
+- [ ] **Step 2: Service input**
+
+`service.ts` `buildAgentConfig({...})` call site(s): add `projects: input.projects,` next to `knowledgePacks: input.knowledgePacks,`. Add `projects?: string[]` to `UpdateAgentInput` (domain.ts) and the create input.
+
+- [ ] **Step 3: HTTP**
+
+`http.ts`: PATCH body gains (next to knowledgePacks, line ~195):
+```typescript
+          projects: t.Optional(t.Array(t.String({ minLength: 1 }))),
+```
+`toAgentResponse` gains (next to knowledgePacks, line ~35):
+```typescript
+    projects: rc.projects,
+```
+Validation in the PATCH handler (before `svc.update`): every id must exist —
+```typescript
+          if (body.projects) {
+            for (const pid of body.projects) {
+              if (!projectSvc.exists(pid)) {
+                return Response.json(
+                  { error: `unknown project ${pid}` },
+                  { status: 400 },
+                );
+              }
+            }
+          }
+```
+`projectSvc` must be threaded into the agent routes factory (check its current factory signature in `http.ts` and the wiring in `bootstrap/features.ts`; add a `projectExists: (id: string) => boolean` dep if threading the whole service is awkward).
+
+- [ ] **Step 4: Round-trip test**
+
+```typescript
+test("projects field round-trips through agent.yml", () => {
+  const cfg = buildAgentConfig({
+    id: "a1",
+    name: "A",
+    prev: undefined,
+    projects: ["p1", "p2"],
+  });
+  const yaml = serializeAgentYaml(cfg);
+  expect(yaml).toContain("  projects:");
+  expect(yaml).toContain("- p1");
+  const parsed = agentConfigSchema.parse(parseYamlLike(yaml)); // use the existing parse helper in the test file
+  expect(parsed.runtime_config.projects).toEqual(["p1", "p2"]);
+});
+```
+Adapt `parseYamlLike` to the file's existing parse helper name — the round-trip pattern already exists for knowledge_packs; mirror it.
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `cd apps/backend && bun test src/features/agent/ && bunx tsc --noEmit -p tsconfig.test.json`
+Expected: pass, clean.
+
+```bash
+git add apps/backend/src/features/agent/
+git commit -m "feat(agent): agent.yml declares attached projects (many-to-many)"
+```
+
+---
+
+## Task 3: Reconcile materializes worktrees
+
+**Files:**
+- Modify: `apps/backend/src/features/agent/workspace-bridge.ts` (reconcileAgentResources gains a hook)
+- Modify: `apps/backend/src/bootstrap/features.ts` (reconcileAgent.fn body)
+- Test: extend `apps/backend/src/features/agent/workspace-bridge.test.ts`
+
+- [ ] **Step 1: Bridge hook**
+
+`reconcileAgentResources` gains an optional async callback the composition root provides (keeps the bridge sync and testable):
+
+```typescript
+export function reconcileAgentResources(input: {
+  workspacePath: string;
+  kind: string;
+  skillPacks: readonly SkillLink[];
+  mcpServers: readonly McpServerEntry[];
+  productTools: readonly unknown[];
+  knowledgePacks: ReadonlyArray<{ id: string; source: string; name: string; description: string }>;
+  /** Extra workspace roots (project worktrees) receiving the same mcp +
+   *  product-tools bridge (ADR 0023). The caller materializes them. */
+  extraRoots?: readonly string[];
+}): void {
+  const roots = [input.workspacePath, ...(input.extraRoots ?? [])];
+  for (const root of roots) {
+    writeMcpConfig(root, input.mcpServers);
+    writeProductToolsManifest(root, input.productTools);
+  }
+  reconcileSkillLinks(input.workspacePath, input.kind, input.skillPacks);
+  reconcileKnowledgeResources(input.workspacePath, input.knowledgePacks);
+  writeClaudeSettings(input.workspacePath);
+}
+```
+
+- [ ] **Step 2: Composition root**
+
+In `features.ts` `reconcileAgent.fn` (after the existing resource gathering, before `reconcileAgentResources`):
+
+```typescript
+          // ADR 0023: materialize a worktree per attached project and
+          // bridge the same config into it. Failures warn, never throw.
+          const extraRoots: string[] = [];
+          for (const pid of agent.config.runtime_config.projects) {
+            const project = projectSvc.getById(pid) as
+              | { projectId: string; repoUrl: string | null; defaultBranch: string | null }
+              | null;
+            if (!project?.repoUrl) {
+              console.warn(`[reconcile] agent ${agentId}: project ${pid} missing or no repoUrl, skipped`);
+              continue;
+            }
+            try {
+              const mirror = await ensureMirror(config.dataDir, {
+                projectId: project.projectId,
+                repoUrl: project.repoUrl,
+                defaultBranch: project.defaultBranch,
+              });
+              const wt = await ensureWorktree(mirror, agent.workspacePath, {
+                projectId: project.projectId,
+                repoUrl: project.repoUrl,
+                defaultBranch: project.defaultBranch,
+              }, agentId);
+              if (wt) extraRoots.push(wt);
+              else console.warn(`[reconcile] agent ${agentId}: worktree slot for ${pid} occupied, skipped`);
+            } catch (err) {
+              console.warn(`[reconcile] agent ${agentId}: worktree for ${pid} failed:`, err);
+            }
+          }
+```
+
+Pass `extraRoots` into `reconcileAgentResources`. Import `ensureMirror`/`ensureWorktree` from `../features/project/worktree.js` (follow the file's existing relative-import style). Verify `config.dataDir` is the right config field name by reading `apps/backend/src/config.ts`.
+
+Detach cleanup (same fn, before materialize): diff the previous config's projects (fetch via `agentSvc`'s pre-update state — simplest: compare against the DB row before this PATCH wrote it; if not accessible here, do the diff inside the agent service update path and call a `detachWorktrees(projectIds)` callback). Prefer the simpler option that compiles; note the choice in the commit body.
+
+- [ ] **Step 3: Bridge test**
+
+```typescript
+test("reconcileAgentResources bridges mcp + product tools into extra roots", () => {
+  const ws = tmpWorkspace();
+  const wt = tmpWorkspace();
+  reconcileAgentResources({
+    workspacePath: ws,
+    kind: "coding_agent",
+    skillPacks: [],
+    mcpServers: [{ name: "product-tools", transport: "sse", url: "http://127.0.0.1:3005/sse", bearerTokenEnv: "PRODUCT_TOOLS_RUN_TOKEN" }],
+    productTools: [{ name: "history_recent" }],
+    knowledgePacks: [],
+    extraRoots: [wt],
+  });
+  expect(existsSync(join(wt, ".mcp.json"))).toBe(true);
+  expect(existsSync(join(wt, ".agent", "product-tools.json"))).toBe(true);
+});
+```
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `cd apps/backend && bun test src/features/agent/ src/features/project/`
+Expected: pass.
+
+```bash
+git add apps/backend/src/features/agent/workspace-bridge.ts apps/backend/src/bootstrap/features.ts apps/backend/src/features/agent/workspace-bridge.test.ts
+git commit -m "feat(backend): reconcile materializes project worktrees + bridges config"
+```
+
+---
+
+## Task 4: Migration 0032 + conversation.projectId
+
+**Files:**
+- Create: `apps/backend/drizzle/backend/0032_project_worktree.sql`
+- Modify: `apps/backend/drizzle/backend/meta/_journal.json`
+- Modify: `apps/backend/src/infra/db/schema.ts` (conversation column + drop auto_orchestrate + select transform)
+- Modify: `apps/backend/src/features/conversation/ports.ts`, `adapter-sqlite.ts`, `http.ts`
+- Modify: `apps/backend/src/features/project/domain.ts`, `service.ts`, `http.ts`, `adapter-sqlite.ts` (autoOrchestrate removal)
+
+- [ ] **Step 1: Migration file**
+
+```sql
+ALTER TABLE conversation ADD COLUMN project_id text REFERENCES project(project_id) ON DELETE RESTRICT;
+--> statement-breakpoint
+ALTER TABLE project DROP COLUMN auto_orchestrate;
+```
+
+Journal entry (append, `when` > 1786606000000 — e.g. 1786700000000):
+```json
+ {
+  "idx": 32,
+  "version": "6",
+  "when": 1786700000000,
+  "tag": "0032_project_worktree",
+  "breakpoints": true
+ }
+```
+
+- [ ] **Step 2: Schema + types**
+
+`schema.ts`: conversation table gains
+```typescript
+    /** Project binding (ADR 0023): runs in this conversation use the
+     *  project worktree as cwd. Null = agent workspace (default). */
+    projectId: text("project_id").references(() => project.projectId, { onDelete: "restrict" }),
+```
+Delete the `autoOrchestrate` column + its select transform. Follow the existing select-schema block to add `projectId` passthrough.
+
+`ports.ts` `CreateConversationInput` gains `projectId?: string | null;`; `ConversationRow` gains `projectId: string | null;`. Adapter `createConversation` inserts it; `getConversation` returns it (drizzle select covers new columns automatically). HTTP: create body gains `projectId: t.Optional(t.String())` (validate exists → 400), GET /:id response gains `projectId: conv.projectId`.
+
+- [ ] **Step 3: autoOrchestrate removal (project feature)**
+
+Delete from `domain.ts` (ProjectRow/Create/Update inputs), `service.ts` (create/update signatures + port calls), `http.ts` (body fields), `adapter-sqlite.ts` (insert/update mappings). Run `grep -rn autoOrchestrate apps/backend/src` → expect zero hits.
+
+- [ ] **Step 4: Migration + typecheck verify**
+
+Run: `cd apps/backend && bunx tsc --noEmit -p tsconfig.test.json && bun test src/infra/`
+Expected: clean; db tests green (fresh-boot applies 0032).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/drizzle apps/backend/src/infra/db/schema.ts apps/backend/src/features/conversation apps/backend/src/features/project
+git commit -m "feat(backend): conversation project binding + drop dead auto_orchestrate"
+```
+
+---
+
+## Task 5: resolveWorkspace → worktree
+
+**Files:**
+- Modify: `apps/backend/src/bootstrap/features.ts` (resolveWorkspace)
+- Test: extend `apps/backend/src/features/agent-run/execution.test.ts`
+
+- [ ] **Step 1: resolveWorkspace logic**
+
+```typescript
+    resolveWorkspace: async ({ conversationId, agentMemberId }) => {
+      const members = conv.convPort.getMembers(conversationId);
+      const member = members.find((m) => m.memberId === agentMemberId);
+      const agent = member?.agentId ? await agentSvc.getById(member.agentId) : null;
+      const access = agent?.config.runtime_config.permission_mode === "ask"
+        ? "read_only"
+        : "read_write";
+      const convRow = conv.convPort.getConversation(conversationId);
+      if (convRow?.projectId) {
+        const attached = agent?.config.runtime_config.projects.includes(convRow.projectId);
+        if (!attached) {
+          throw new Error(
+            `agent ${member?.agentId ?? "?"} has not attached project ${convRow.projectId}; ` +
+              `attach it on the agent page (agent.yml runtime_config.projects)`,
+          );
+        }
+        const wt = join(agent!.workspacePath, "projects", convRow.projectId);
+        return { root: existsSync(wt) ? wt : agent!.workspacePath, access };
+      }
+      return { root: agent?.workspacePath ?? config.workspaceRoot, access };
+    },
+```
+Notes: read the current body first (field names may differ slightly — `config.workspaceRoot` vs `workspaceRoot`); preserve existing fallbacks. The not-attached case throws → dispatch's failure path (run failed + status event) — verify by reading dispatchInner; if `resolveWorkspace` is called outside a try, move the throw so it lands inside one.
+
+- [ ] **Step 2: execution test**
+
+Add to execution.test.ts:
+
+```typescript
+  test("conversation project binding: run cwd is the agent's worktree", async () => {
+    const fake = createFakeDaemon();
+    const execution = makeExecution(fake);
+    // attach project p1 to the agent under test + create conversation with projectId
+    // (use the same helpers the file already uses to set up agent+conversation;
+    //  set agent config projects: ["p1"] and conversation projectId: "p1",
+    //  materialize the worktree dir by hand: mkdir <agentWs>/projects/p1)
+    const acquired = await enqueue("normal", "wt-1", "hello");
+    await execution.dispatch(acquired.run!.runId);
+    await waitForTerminal(acquired.run!.runId);
+    expect(fake.executeCalls[0]?.workspaceRoot).toBe(join(agentWs, "projects", "p1"));
+  });
+```
+Materialize the setup with the file's existing fixtures; the fake daemon already records `workspaceRoot` per execute. Also assert the not-attached case: conversation projectId "p9" (never attached) → run status failed, error contains "has not attached project".
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `cd apps/backend && bun test src/features/agent-run/`
+Expected: pass.
+
+```bash
+git add apps/backend/src/bootstrap/features.ts apps/backend/src/features/agent-run/execution.test.ts
+git commit -m "feat(backend): runs in project-bound conversations use the worktree as cwd"
+```
+
+---
+
+## Task 6: project delete guard + web touches
+
+**Files:**
+- Modify: `apps/backend/src/features/project/service.ts` (delete guard)
+- Modify: `apps/web/src/app/(main)/team/[agentId]/page.tsx` + `_components/` (projects picker)
+- Modify: `apps/web/src/app/(main)/chat/page.tsx` (conversation project select)
+- Modify: `apps/web/src/lib/api.ts` (types if hand-written)
+
+- [ ] **Step 1: delete guard**
+
+`service.ts` `remove`: before deleting, scan agents (inject `listAgentsWithConfig: () => Array<{ id: string; workspacePath: string; config: { runtime_config: { projects: string[] } } }>` dep from the composition root) —
+
+```typescript
+    remove(id: string): void {
+      const attached = listAgentsWithConfig().filter((a) =>
+        a.config.runtime_config.projects.includes(id),
+      );
+      if (attached.length > 0) {
+        throw new ConflictError(
+          `project ${id} still attached to: ${attached.map((a) => a.id).join(", ")}`,
+        );
+      }
+      if (!port.deleteProject(id)) throw new ProjectNotFoundError(id);
+    },
+```
+Wire the dep in `bootstrap/features.ts`. HTTP: ConflictError already maps to 409 (verify in the error handler; if not, add).
+
+- [ ] **Step 2: web — agent detail projects picker**
+
+In the agent detail `_components/`, add a Projects section modeled on the existing MCP/knowledge toggles: list all projects (`api.listProjects()`), checkbox per row, mutation `api.updateAgent(id, { projects: checkedIds })`. Reuse the existing toggle-list component pattern from the agent detail page (read it first; do not invent a new pattern).
+
+- [ ] **Step 3: web — chat new-conversation project select**
+
+`chat/page.tsx` handleCreate body gains `projectId` when selected (a small `<select>` fed by `api.listProjects()` next to the agent select; empty option = none). `api.ts` createConversation body type gains `projectId?: string`.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `cd apps/web && bunx tsc --noEmit -p tsconfig.json && bun test`
+Expected: clean, pass. Manual smoke: build not required at this step if audit untouched; final gate runs in Task 7.
+
+```bash
+git add apps/backend/src/features/project apps/backend/src/bootstrap/features.ts apps/web/src
+git commit -m "feat(web): project picker on agent detail + conversation project binding"
+```
+
+---
+
+## Task 7: Full gates + E2E smoke + close
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-14-project-worktree-p1-design.md` (check the §6 boxes)
+
+- [ ] **Step 1: Full gates**
+
+Run: `cd /root/my-agent-team && bun run typecheck && bun run lint && bun run test`
+Expected: all green.
+
+- [ ] **Step 2: E2E smoke (live)**
+
+1. Restart backend (`hub restart backend`).
+2. Create a local source repo; create project via `POST /api/projects` with its `file://` (or absolute) path.
+3. `PATCH /api/agents/default {projects:["<id>"]}` → verify `<defaultWs>/projects/<id>/.mcp.json` exists.
+4. Create conversation with `projectId`, send a message → run's workspace root is the worktree (fake the model the same way existing E2E smoke does, or verify via the run's dispatch when no model: check reconcile + files only and record the model-catalog limitation as before).
+
+- [ ] **Step 3: Acceptance sweep (spec §6)**
+
+- `grep -rn autoOrchestrate apps/backend/src` → zero.
+- Worktree idempotency: re-run PATCH → no errors, files stable.
+- Not-attached conversation → failed run with actionable error.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add docs/superpowers/specs/2026-08-14-project-worktree-p1-design.md
+git commit -m "docs(docs): project worktree P1 acceptance verified"
+git push
+```

--- a/docs/superpowers/plans/2026-08-14-project-worktree-p2.md
+++ b/docs/superpowers/plans/2026-08-14-project-worktree-p2.md
@@ -1,0 +1,717 @@
+# Project Worktree P2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Loops run in per-agent git worktrees (per-step clone retired) and the project aggregate page shows branch status/diff with in-page fast-forward/merge.
+
+**Architecture:** LOOP.md gains a top-level `agent` field (default "default"); `resolveLoopWorktree` replaces `resolveRepoPath` by reusing P1's `ensureMirror`/`ensureWorktree` plus a per-step `reset --hard` to the default branch. Merge ops (`worktree-ops.ts`) run entirely inside the bare mirror (rev-list / merge-tree / branch -f plumbing — never touching live worktrees), with optional push. The web project page becomes an aggregate: worktree cards with ahead/behind, diff, FF/Merge actions.
+
+**Tech Stack:** Bun 1.3 + `Bun.$` git plumbing, packages/loop config parser (zod-free YAML frontmatter), Elysia HTTP, Next.js 15 + existing polish atoms, bun:test with real git fixtures.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-project-worktree-p2-design.md`
+
+**Hard rules from repo/session:**
+- commitlint: scope in parentheses, no CJK, body lines ≤100 chars.
+- No `as unknown as` (test-double boundary exception only); no python/sed to edit source — read+edit.
+- Real wall-clock waits in tests are forbidden (`ts-no-test-timers`); poll awaited conditions instead.
+- Loop package is source-only (no build); backend rebuilds after `packages/loop` changes are not needed — but run `bun run build --filter=@my-agent-team/loop` is NOT a script; just typecheck.
+
+---
+
+## Task 1: LoopConfig `agent` field
+
+**Files:**
+- Modify: `packages/loop/src/state-md.ts` (LoopConfig + parseLoopConfig)
+- Modify: `apps/backend/src/features/loop/loop-service.ts` (writeDefaultLoopMd + create input)
+- Modify: `apps/backend/src/features/loop/http.ts` (create body)
+- Test: `packages/loop/src/state-md.test.ts` (extend)
+
+- [ ] **Step 1: Failing test**
+
+```typescript
+test("parseLoopConfig reads the agent field with default back-compat", () => {
+  const withAgent = parseLoopConfig(LOOP_MD_HEADER + "\nagent: coder-1\n" + LOOP_MD_BODY);
+  expect(withAgent?.agent).toBe("coder-1");
+  const without = parseLoopConfig(LOOP_MD_HEADER + "\n" + LOOP_MD_BODY);
+  expect(without?.agent).toBe("default");
+});
+```
+
+Adapt `LOOP_MD_HEADER`/`LOOP_MD_BODY` to the test file's existing LOOP.md fixture style (a minimal frontmatter with projectId + differing generator/evaluator models). If the file uses inline strings, write the full minimal doc inline.
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `cd packages/loop && bun test src/state-md.test.ts`
+Expected: FAIL — `agent` does not exist on LoopConfig.
+
+- [ ] **Step 3: Implement**
+
+`state-md.ts`:
+
+```typescript
+export interface LoopConfig {
+  projectId: string;
+  /** The agent whose (agent, project) worktree runs this loop's steps
+   *  (ADR 0023 P2). Empty string = "default" (back-compat). */
+  agent: string;
+  // ...rest unchanged
+}
+```
+
+In `parseLoopConfig`'s return object add:
+```typescript
+    agent: String(frontmatter.agent ?? "default") || "default",
+```
+
+`loop-service.ts` `writeDefaultLoopMd`: add `agent: string | undefined` to the signature; emit after projectId:
+```typescript
+      `projectId: ${projectId ?? ""}`,
+      `agent: ${agent ?? "default"}`,
+```
+Call sites (loop-service.ts:217 and ~245): pass `input.agent` (create path) and `undefined` (default path). Add `agent?: string` to the create input type (near `projectId?: string`, line ~153).
+
+`loop/http.ts` create body (~line 95): `agent: t.Optional(t.String({ minLength: 1 })),` and pass through to the service call (~line 84: `agent: body.agent,`).
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `cd packages/loop && bun test && cd ../../apps/backend && bunx tsc --noEmit -p tsconfig.test.json`
+Expected: pass, clean.
+
+```bash
+git add packages/loop/src/state-md.ts packages/loop/src/state-md.test.ts apps/backend/src/features/loop/loop-service.ts apps/backend/src/features/loop/http.ts
+git commit -m "feat(loop): LOOP.md agent field - which agent's worktree runs the loop"
+```
+
+---
+
+## Task 2: resolveLoopWorktree replaces the per-step clone
+
+**Files:**
+- Modify: `apps/backend/src/features/loop/loop-step.ts` (resolveRepoPath → resolveLoopWorktree; ensureLoopScope routing)
+- Modify: `apps/backend/src/features/loop/loop-step.test.ts` (fixtures)
+- Modify: `apps/backend/src/features/cron/scheduler.ts` + `apps/backend/src/features/loop/loop-service.ts` + `apps/backend/src/features/loop/http.ts` (params plumbing)
+- Modify: `apps/backend/src/bootstrap/features.ts` (wire agentWorkspaceOf)
+
+- [ ] **Step 1: Replace the resolver**
+
+In `loop-step.ts`, delete `resolveRepoPath` (lines 114-152) and add:
+
+```typescript
+/** Resolve the loop agent's (agent, project) worktree and hard-reset it to
+ *  the project's default branch — the per-step clean start (ADR 0023 P2;
+ *  replaces the retired per-step shallow clone). Returns null when the
+ *  loop has no projectId. */
+export async function resolveLoopWorktree(
+  loopConfigPath: string,
+  deps: {
+    projectPort: ProjectPort | undefined;
+    dataDir: string | undefined;
+    agentWorkspaceOf: (agentId: string) => Promise<string | null>;
+  },
+): Promise<string | null> {
+  const { projectPort, dataDir, agentWorkspaceOf } = deps;
+  if (!projectPort || !dataDir) return null;
+  let cfg: LoopConfig | null;
+  try {
+    cfg = parseLoopConfig(await Bun.file(`${loopConfigPath}/LOOP.md`).text());
+  } catch {
+    return null;
+  }
+  const projectId = cfg?.projectId;
+  if (!projectId) return null;
+  const project = projectPort.getProject(projectId);
+  if (!project?.repoUrl) {
+    throw new Error(`loopStep: project ${projectId} has no repoUrl`);
+  }
+  const agentId = cfg?.agent || "default";
+  const agentWs = await agentWorkspaceOf(agentId);
+  if (!agentWs) {
+    throw new Error(`loopStep: LOOP.md agent "${agentId}" not found`);
+  }
+  const mirror = await ensureMirror(dataDir, {
+    projectId: project.projectId,
+    repoUrl: project.repoUrl,
+    defaultBranch: project.defaultBranch,
+  });
+  const wt = await ensureWorktree(
+    mirror,
+    agentWs,
+    {
+      projectId: project.projectId,
+      repoUrl: project.repoUrl,
+      defaultBranch: project.defaultBranch,
+    },
+    agentId,
+  );
+  if (!wt) {
+    throw new Error(`loopStep: worktree slot occupied at ${join(agentWs, "projects", projectId)}`);
+  }
+  const branch = project.defaultBranch ?? "HEAD";
+  await Bun.$`git -C ${wt} reset --hard ${branch === "HEAD" ? "refs/remotes/origin/HEAD" : `refs/heads/${branch}`}`.quiet();
+  return wt;
+}
+```
+
+Import `ensureMirror, ensureWorktree` from `../project/worktree.js`. Replace the call site in `loopStepImpl` (line ~249):
+
+```typescript
+  const cwd = await resolveLoopWorktree(params.loopConfigPath, {
+    projectPort: params.projectPort,
+    dataDir: params.dataDir,
+    agentWorkspaceOf: params.agentWorkspaceOf,
+  });
+```
+
+(The old binding was `const repoPath = ...` then `cwd` came from it — read the current lines 249-260 and keep whatever else used `repoPath` pointing at `cwd`.) Rename the variable so every later `cwd` use is untouched.
+
+Add to `LoopStepParams`:
+
+```typescript
+  /** Resolve a LOOP.md agent id to its workspace path (null = unknown
+   *  agent). Wired from the composition root via agentSvc. */
+  agentWorkspaceOf: (agentId: string) => Promise<string | null>;
+```
+
+- [ ] **Step 2: ensureLoopScope routing**
+
+Line ~390: `ensureLoopScope(params.convPort, genConversationId, genMemberId, "default")` → read `cfg` first (it is parsed later at the moment — hoist the LOOP.md parse above the scope creation, or re-read cheaply):
+
+```typescript
+    await ensureLoopScope(params.convPort, genConversationId, genMemberId, cfg.agent || "default");
+```
+
+Check the evaluator's `ensureLoopScope` call too — same change.
+
+- [ ] **Step 3: Plumbing**
+
+- `scheduler.ts` fireLoop params: add `agentWorkspaceOf: deps.agentWorkspaceOf,` and add the dep to `createCronScheduler`'s deps interface: `agentWorkspaceOf: (agentId: string) => Promise<string | null>;`
+- `loop-service.ts` `runLoop` deps + the `loopStepDeps` object in `http.ts`: same field.
+- `bootstrap/features.ts`: `createCronScheduler({...})` gains:
+  ```typescript
+    agentWorkspaceOf: async (id: string) => {
+      const agent = await agentSvc.getById(id).catch(() => null);
+      return agent?.workspacePath ?? null;
+    },
+  ```
+  and the same object into the loop http wiring (find where `loopStepDeps` gets its deps in features.ts — search `loopRoutes(`).
+
+- [ ] **Step 4: Test fixtures**
+
+In `loop-step.test.ts`, the tests that exercise repo behavior build a fixture repo and (currently) rely on the clone path. Update:
+- Provide `agentWorkspaceOf: async () => <loopAgentWs>` (a tmp dir) in the params objects.
+- After the step, assert the run's workspace root is `join(loopAgentWs, "projects", <projectId>)` (the worktree), not `dataDir/repos/...`.
+- Any literal `repos/` path expectations are deleted.
+- `git reset --hard` in the resolver runs against the real fixture repo — the existing GitRunner mock only covers rollback calls; the resolver's own git is real Bun.$ (same as the old clone path was).
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `cd apps/backend && bun test src/features/loop/ && bunx tsc --noEmit -p tsconfig.test.json`
+Expected: pass, clean. Then `grep -rn "resolveRepoPath\|dataDir/repos" apps/backend/src --include="*.ts"` → zero hits outside the bootstrap info note (add one `console.info` in features.ts near the scheduler wiring: legacy `dataDir/repos` clones are no longer read and may be deleted manually — cite the path).
+
+```bash
+git add apps/backend/src packages/loop/src
+git commit -m "feat(loop): loop steps run in the agent worktree, per-step clone retired"
+```
+
+---
+
+## Task 3: worktree-ops (status/diff/fast-forward/merge)
+
+**Files:**
+- Create: `apps/backend/src/features/project/worktree-ops.ts`
+- Test: `apps/backend/src/features/project/worktree-ops.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```typescript
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createWorktreeOps, type WorktreeStatus } from "./worktree-ops.js";
+import type { ProjectPort } from "./ports.js";
+
+const dirs: string[] = [];
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+/** source repo: main + one commit; returns repo path. */
+async function makeSource(dir: string, extraCommitOnMain = false): Promise<string> {
+  const src = join(dir, "src");
+  mkdirSync(src, { recursive: true });
+  await Bun.$`git init -b main ${src}`.quiet();
+  await Bun.$`git -C ${src} config user.email t@t`.quiet();
+  await Bun.$`git -C ${src} config user.name t`.quiet();
+  await Bun.$`echo base > ${join(src, "F.txt")}`.quiet();
+  await Bun.$`git -C ${src} add -A && git -C ${src} commit -m base`.quiet();
+  if (extraCommitOnMain) {
+    await Bun.$`echo main2 > ${join(src, "G.txt")}`.quiet();
+    await Bun.$`git -C ${src} add -A && git -C ${src} commit -m main2`.quiet();
+  }
+  return src;
+}
+
+function fakeProjectPort(repoUrl: string, projectId: string): ProjectPort {
+  return {
+    createProject: () => {
+      throw new Error("unused");
+    },
+    getProject: (id: string) =>
+      id === projectId
+        ? {
+            projectId,
+            name: "p",
+            repoUrl,
+            defaultBranch: "main",
+            createdAt: 0,
+            updatedAt: 0,
+          }
+        : null,
+    listProjects: () => [],
+    updateProject: () => null,
+    deleteProject: () => false,
+  } as unknown as ProjectPort;
+}
+
+const PID = "pp";
+
+describe("worktree ops", () => {
+  test("status counts ahead/behind; fast-forward moves base; divergence refused; conflicts 409", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wops-"));
+    dirs.push(dir);
+    const src = await makeSource(dir);
+    const dataDir = join(dir, "data");
+    const agentWs = join(dir, "agent");
+    mkdirSync(agentWs, { recursive: true });
+
+    // Materialize the worktree via the P1 plumbing (setup, not under test).
+    const { ensureMirror, ensureWorktree } = await import("./worktree.js");
+    const mirror = await ensureMirror(dataDir, {
+      projectId: PID,
+      repoUrl: src,
+      defaultBranch: "main",
+    });
+    await ensureWorktree(
+      mirror,
+      agentWs,
+      { projectId: PID, repoUrl: src, defaultBranch: "main" },
+      "a1",
+    );
+    // A commit on the agent branch (work directly in the mirror: plumbing).
+    const wt = join(agentWs, "projects", PID);
+    await Bun.$`echo work > ${join(wt, "W.txt")}`.quiet();
+    await Bun.$`git -C ${wt} add -A && git -C ${wt} -c user.email=t@t -c user.name=t commit -m w`.quiet();
+
+    const ops = createWorktreeOps({
+      dataDir,
+      projectPort: fakeProjectPort(src, PID),
+      listAgentConfigs: async () => [{ id: "a1", workspacePath: agentWs, projects: [PID] }],
+    });
+
+    const st = await ops.status(PID);
+    expect(st).toHaveLength(1);
+    expect(st[0]).toMatchObject({ agentId: "a1", ahead: 1, behind: 0, worktreeReady: true });
+
+    const diff = await ops.diff(PID, "a1");
+    expect(diff).toContain("W.txt");
+
+    await ops.fastForward(PID, "a1", { push: false });
+    const st2 = await ops.status(PID);
+    expect(st2[0]?.ahead).toBe(0);
+
+    // Divergence: new commit on main + new commit on agent branch.
+    await Bun.$`git -C ${src} -c user.email=t@t -c user.name=t commit --allow-empty -m m2`.quiet();
+    await Bun.$`git -C ${mirror} fetch --prune origin`.quiet();
+    await Bun.$`git -C ${wt} -c user.email=t@t -c user.name=t commit --allow-empty -m w2`.quiet();
+    await expect(ops.fastForward(PID, "a1", { push: false })).rejects.toThrow(/diverged/);
+  }, 20_000);
+
+  test("merge with conflicting changes reports the conflict files", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wops2-"));
+    dirs.push(dir);
+    const src = await makeSource(dir);
+    const dataDir = join(dir, "data");
+    const agentWs = join(dir, "agent");
+    mkdirSync(agentWs, { recursive: true });
+    const { ensureMirror, ensureWorktree } = await import("./worktree.js");
+    const mirror = await ensureMirror(dataDir, {
+      projectId: PID,
+      repoUrl: src,
+      defaultBranch: "main",
+    });
+    const wt = await ensureWorktree(
+      mirror,
+      agentWs,
+      { projectId: PID, repoUrl: src, defaultBranch: "main" },
+      "a1",
+    );
+    if (!wt) throw new Error("worktree setup failed");
+    // Agent edits F.txt; main also edits F.txt -> conflict.
+    await Bun.$`echo agent > ${join(wt, "F.txt")}`.quiet();
+    await Bun.$`git -C ${wt} add -A && git -C ${wt} -c user.email=t@t -c user.name=t commit -m a`.quiet();
+    await Bun.$`git -C ${src} echo main > ${join(src, "F.txt")}`.quiet();
+    await Bun.$`git -C ${src} add -A && git -C ${src} -c user.email=t@t -c user.name=t commit -m m`.quiet();
+    await Bun.$`git -C ${mirror} fetch --prune origin`.quiet();
+
+    const ops = createWorktreeOps({
+      dataDir,
+      projectPort: fakeProjectPort(src, PID),
+      listAgentConfigs: async () => [{ id: "a1", workspacePath: agentWs, projects: [PID] }],
+    });
+    await expect(ops.merge(PID, "a1", { push: false })).rejects.toThrow(/F\.txt/);
+  }, 20_000);
+});
+```
+
+NOTE: `git -C ${src} echo main > ...` is wrong — the implementer must write it as `await Bun.$`echo main > ${join(src, "F.txt")}`.quiet();` (the redirect is shell-level). Fix while typing; the intent is: source file changed on main.
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `cd apps/backend && bun test src/features/project/worktree-ops.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { ConflictError } from "../../infra/domain-errors.js";
+import type { ProjectPort } from "./ports.js";
+import { ensureMirror } from "./worktree.js";
+
+export interface WorktreeStatus {
+  agentId: string;
+  branch: string;
+  ahead: number;
+  behind: number;
+  worktreeReady: boolean;
+}
+
+export interface WorktreeOps {
+  status(projectId: string): Promise<WorktreeStatus[]>;
+  diff(projectId: string, agentId: string): Promise<string>;
+  fastForward(projectId: string, agentId: string, opts: { push: boolean }): Promise<void>;
+  merge(projectId: string, agentId: string, opts: { push: boolean }): Promise<void>;
+}
+
+/** Read/merge operations over a project's agent worktrees. All git runs in
+ *  the bare mirror (plumbing) — never in a live worktree (a run may hold
+ *  it). Base moves are branch -f only; two-sided merges are refused (see
+ *  the spec's honest boundary). */
+export function createWorktreeOps(deps: {
+  dataDir: string;
+  projectPort: ProjectPort;
+  listAgentConfigs: () => Promise<Array<{ id: string; workspacePath: string; projects: string[] }>>;
+}): WorktreeOps {
+  const mirrorOf = async (projectId: string): Promise<string> => {
+    const project = deps.projectPort.getProject(projectId);
+    if (!project?.repoUrl) throw new Error(`project ${projectId} has no repoUrl`);
+    return ensureMirror(deps.dataDir, {
+      projectId: project.projectId,
+      repoUrl: project.repoUrl,
+      defaultBranch: project.defaultBranch,
+    });
+  };
+
+  const baseRef = async (projectId: string): Promise<string> => {
+    const project = deps.projectPort.getProject(projectId);
+    return project?.defaultBranch ?? "origin/HEAD";
+  };
+
+  const pushBase = async (mirror: string, base: string): Promise<void> => {
+    const res = await Bun.$`git -C ${mirror} push origin ${base}`.quiet().nothrow();
+    if (res.exitCode !== 0) {
+      throw new Error(`push failed: ${res.stderr.toString().slice(0, 200)}`);
+    }
+  };
+
+  return {
+    async status(projectId) {
+      const mirror = await mirrorOf(projectId);
+      const base = await baseRef(projectId);
+      const agents = (await deps.listAgentConfigs()).filter((a) => a.projects.includes(projectId));
+      const out: WorktreeStatus[] = [];
+      for (const a of agents) {
+        const branch = `agent/${a.id}/${projectId}`;
+        const has =
+          (await Bun.$`git -C ${mirror} show-ref --verify refs/heads/${branch}`.quiet().nothrow())
+            .exitCode === 0;
+        if (!has) continue;
+        const counts = await Bun.$`git -C ${mirror} rev-list --left-right --count ${base}...${branch}`
+          .quiet()
+          .text();
+        const [behind, ahead] = counts.trim().split(/\s+/).map(Number);
+        out.push({
+          agentId: a.id,
+          branch,
+          ahead: ahead ?? 0,
+          behind: behind ?? 0,
+          worktreeReady: existsSync(join(a.workspacePath, "projects", projectId)),
+        });
+      }
+      return out;
+    },
+
+    async diff(projectId, agentId) {
+      const mirror = await mirrorOf(projectId);
+      const base = await baseRef(projectId);
+      return Bun.$`git -C ${mirror} diff ${base}...agent/${agentId}/${projectId}`.quiet().text();
+    },
+
+    async fastForward(projectId, agentId, opts) {
+      const mirror = await mirrorOf(projectId);
+      const base = await baseRef(projectId);
+      const branch = `agent/${agentId}/${projectId}`;
+      const counts = await Bun.$`git -C ${mirror} rev-list --left-right --count ${base}...${branch}`
+        .quiet()
+        .text();
+      const [behind] = counts.trim().split(/\s+/).map(Number);
+      if ((behind ?? 0) > 0) {
+        throw new ConflictError(`fast-forward refused: ${base} diverged from ${branch}`);
+      }
+      await Bun.$`git -C ${mirror} branch -f ${base} ${branch}`.quiet();
+      if (opts.push) await pushBase(mirror, base);
+    },
+
+    async merge(projectId, agentId, opts) {
+      const mirror = await mirrorOf(projectId);
+      const base = await baseRef(projectId);
+      const branch = `agent/${agentId}/${projectId}`;
+      // merge-tree preflight: conflict markers appear as changed lines.
+      const tree = await Bun.$`git -C ${mirror} merge-tree --write-tree ${base} ${branch}`
+        .quiet()
+        .nothrow();
+      const text = tree.text();
+      if (tree.exitCode !== 0 || text.includes("<<<<<<<")) {
+        const files = text
+          .split("\n")
+          .filter((l) => l && !l.startsWith("-") && !l.startsWith("+"))
+          .slice(1, 11)
+          .join(", ");
+        throw new ConflictError(`merge conflicts: ${files || "see merge-tree output"}`);
+      }
+      const counts = await Bun.$`git -C ${mirror} rev-list --left-right --count ${base}...${branch}`
+        .quiet()
+        .text();
+      const [behind] = counts.trim().split(/\s+/).map(Number);
+      if ((behind ?? 0) > 0) {
+        throw new ConflictError(
+          `diverged; merge both branches manually (base has commits not on agent/${agentId})`,
+        );
+      }
+      await Bun.$`git -C ${mirror} branch -f ${base} ${branch}`.quiet();
+      if (opts.push) await pushBase(mirror, base);
+    },
+  };
+}
+```
+
+The `merge-tree --write-tree` flag exists in git ≥ 2.38 (box has 2.39). If the parse proves brittle, the fallback is `git merge-tree <base> <branch>` (old form) and grep for `changed in both` — implement what passes the test honestly.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `cd apps/backend && bun test src/features/project/`
+Expected: all pass (worktree + ops suites).
+
+```bash
+git add apps/backend/src/features/project/worktree-ops.ts apps/backend/src/features/project/worktree-ops.test.ts
+git commit -m "feat(backend): worktree ops - status, diff, fast-forward, merge in the mirror"
+```
+
+---
+
+## Task 4: HTTP endpoints
+
+**Files:**
+- Modify: `apps/backend/src/features/project/http.ts`
+- Modify: `apps/backend/src/bootstrap/features.ts` (wire ops)
+- Test: extend `apps/backend/src/features/project/http.test.ts`
+
+- [ ] **Step 1: Routes**
+
+`projectRoutes` gains an optional `worktreeOps?: WorktreeOps` param; when absent the routes 501 (keeps http.test.ts standalone):
+
+```typescript
+    .get("/api/projects/:id/worktrees", async ({ params: { id } }) => {
+      if (!worktreeOps) return Response.json({ error: "worktree ops unavailable" }, { status: 501 });
+      return { worktrees: await worktreeOps.status(id) };
+    })
+    .get("/api/projects/:id/worktrees/:agentId/diff", async ({ params: { id, agentId } }) => {
+      if (!worktreeOps) return Response.json({ error: "worktree ops unavailable" }, { status: 501 });
+      return { diff: await worktreeOps.diff(id, agentId) };
+    })
+    .post(
+      "/api/projects/:id/worktrees/:agentId/fast-forward",
+      async ({ params: { id, agentId }, body }) => {
+        if (!worktreeOps) return Response.json({ error: "worktree ops unavailable" }, { status: 501 });
+        await worktreeOps.fastForward(id, agentId, { push: body.push === true });
+        return { ok: true };
+      },
+      { body: t.Object({ push: t.Optional(t.Boolean()) }) },
+    )
+    .post(
+      "/api/projects/:id/worktrees/:agentId/merge",
+      async ({ params: { id, agentId }, body }) => {
+        if (!worktreeOps) return Response.json({ error: "worktree ops unavailable" }, { status: 501 });
+        await worktreeOps.merge(id, agentId, { push: body.push === true });
+        return { ok: true };
+      },
+      { body: t.Object({ push: t.Optional(t.Boolean()) }) },
+    )
+```
+
+ConflictError must map to 409 in the shared catch (the delete route already does — extract or duplicate the mapping for these four routes).
+
+- [ ] **Step 2: Bootstrap wiring**
+
+`features.ts`:
+
+```typescript
+  const worktreeOps = createWorktreeOps({
+    dataDir: config.dataDir,
+    projectPort,
+    listAgentConfigs: async () =>
+      (await agentSvc.list(true)).map((a) => ({
+        id: a.id,
+        workspacePath: a.workspacePath,
+        projects: a.config.runtime_config.projects,
+      })),
+  });
+```
+
+Pass into `projectRoutes(projectSvc, worktreeOps)`.
+
+- [ ] **Step 3: Test**
+
+One happy-path test in http.test.ts: a project + attached agent + real repo through the ops (reuse the worktree-ops fixture pattern); GET worktrees returns the status row. A 409 test: call fast-forward on a diverged setup, expect 409 + `diverged` in the body. Keep it lean — the ops logic is covered by Task 3.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `cd apps/backend && bun test src/features/project/ && bunx tsc --noEmit -p tsconfig.test.json`
+Expected: pass, clean.
+
+```bash
+git add apps/backend/src/features/project/http.ts apps/backend/src/features/project/http.test.ts apps/backend/src/bootstrap/features.ts
+git commit -m "feat(backend): project worktree http endpoints - status/diff/ff/merge"
+```
+
+---
+
+## Task 5: Aggregate page
+
+**Files:**
+- Create: `apps/web/src/app/(main)/team/projects/[id]/page.tsx`
+- Create: `apps/web/src/app/(main)/team/projects/_components/worktree-card.tsx`
+- Modify: `apps/web/src/lib/api.ts` (four endpoints + types)
+- Modify: `apps/web/src/app/(main)/team/projects/page.tsx` (row link + agents badge)
+- Modify: `apps/web/scripts/ui-audit.ts` (one assertion)
+
+- [ ] **Step 1: api.ts**
+
+```typescript
+  listProjectWorktrees: (id: string) =>
+    unwrap(client.api.projects({ id }).worktrees.get()),
+  projectWorktreeDiff: (id: string, agentId: string) =>
+    unwrap(client.api.projects({ id }).worktrees({ agentId }).diff.get()),
+  projectWorktreeFastForward: (id: string, agentId: string, push: boolean) =>
+    unwrap(client.api.projects({ id }).worktrees({ agentId })["fast-forward"].post({ push })),
+  projectWorktreeMerge: (id: string, agentId: string, push: boolean) =>
+    unwrap(client.api.projects({ id }).worktrees({ agentId }).merge.post({ push })),
+```
+
+Type derives from the backend App via Eden (no hand-written types needed).
+
+- [ ] **Step 2: Aggregate page**
+
+`[id]/page.tsx` (client component; read an existing detail page for the Page/PageHeader pattern):
+
+- `PageHeader` with project name (query `api.getProject`-equivalent — the list endpoint filtered by id is fine; add `getProject` back to api.ts if absent).
+- Loops section: existing `useLoops()`-style query filtered by `projectId` (loop rows expose projectId? — check the loop list API; if not exposed, filter client-side by the LOOP.md data the loop detail carries; worst case show all loops with a note. Do not change the backend for this).
+- Worktrees section: `api.listProjectWorktrees(id)` → one `WorktreeCard` per row (empty → EmptyState pointing at agent detail).
+
+`worktree-card.tsx`:
+
+```tsx
+"use client";
+// ListRowCard shell: agent id, branch mono chip, ahead/behind badges
+// (ahead>0 = ok tone), worktreeReady warning, expandable diff (first 200
+// lines), FF + Merge buttons behind window.confirm with a push checkbox.
+```
+
+Behaviors: expand lazily fetches the diff once (React state toggle); FF/Merge POST then `invalidateQueries(["project-worktrees", id])`; error toasts carry the backend message (409 diverged surfaces verbatim).
+
+- [ ] **Step 3: Projects list row**
+
+`projects/page.tsx`: row gains an onClick → `/team/projects/<id>` and an `N agents` badge (derive from `useQuery(["agents"])` filtering `a.projects?.includes(id)`).
+
+- [ ] **Step 4: Audit assertion**
+
+In `ui-audit.ts` append:
+
+```typescript
+  {
+    name: "P3-project-detail has a worktree card container",
+    check: async () =>
+      withPage("/team/projects", async (page) => {
+        await loginIfNeeded(page);
+        // Navigate into the first project if the list has one.
+        const has = await page.evaluate(() =>
+          Boolean(document.querySelector('[data-testid="project-worktrees"]')),
+        );
+        // Detail-only container: the list page not having it is fine; open
+        // the first row when present.
+        const first = await page.$("a[href^='/team/projects/']");
+        if (first) {
+          await first.click();
+          await page.waitForSelector('[data-testid="project-worktrees"]', { timeout: 15_000 });
+          return;
+        }
+        if (!has) throw new Error("no projects to audit");
+      }),
+  },
+```
+
+Adjust selector to the actual link markup; the assertion passes when either the empty state renders or a card container appears after navigation.
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `cd apps/web && bunx tsc --noEmit -p tsconfig.json && bun test`
+Expected: clean, pass.
+
+```bash
+git add apps/web/src apps/web/scripts/ui-audit.ts
+git commit -m "feat(web): project aggregate page - worktree cards, diff, ff/merge"
+```
+
+---
+
+## Task 6: Full gates + live E2E + close
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-14-project-worktree-p2-design.md` (check §7 boxes)
+
+- [ ] **Step 1: Full gates**
+
+Run: `cd /root/my-agent-team && bun run typecheck && bun run lint && bun run test`
+Expected: all green.
+
+- [ ] **Step 2: Live E2E (local file:// repo)**
+
+1. Restart backend; reuse or recreate the demo project from P1's smoke.
+2. Create a LOOP.md (via the loop create API with `agent: default` + projectId) — or hand-write `.loop` config; simplest: POST /api/loops with projectId and agent.
+3. Trigger one loop step (POST /api/loops/:id/run) — with no real model the run fails at preflight; that's fine: assert the **worktree was materialized and reset** (mtime/content of `<agentWs>/projects/<pid>`) and the failure reason is model-availability, not worktree.
+4. Aggregate page: open `/team/projects/<id>` in the built web; make a commit on the agent branch manually (`git -C <wt> commit --allow-empty`); verify ahead badge = 1; run FF via the page; verify ahead → 0 and (with push off) no network push attempted.
+
+- [ ] **Step 3: Acceptance sweep**
+
+- `grep -rn "resolveRepoPath\|dataDir/repos" apps/backend/src --include="*.ts"` → only the bootstrap info note.
+- Spec §7 boxes all checked.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add docs/superpowers/specs/2026-08-14-project-worktree-p2-design.md
+git commit -m "docs(docs): project worktree P2 acceptance verified"
+git push
+```

--- a/docs/superpowers/specs/2026-08-14-project-worktree-p1-design.md
+++ b/docs/superpowers/specs/2026-08-14-project-worktree-p1-design.md
@@ -140,9 +140,9 @@ for projectId of agent.config.runtime_config.projects:
 
 ## 6. 验收清单
 
-- [ ] agent.yml `projects` 声明 → worktree 落位 + bridge 文件存在(幂等)
-- [ ] 会话带 projectId 的 run cwd = worktree(context 不变)
-- [ ] 未声明 project 的 run 显式失败,错误可操作
-- [ ] detach 清理 worktree + 分支;project 删除被 attach 阻止
-- [ ] `grep -rn autoOrchestrate apps/backend/src` 零命中
-- [ ] 全仓 typecheck/lint/test 绿 + audit 14/14
+- [x] agent.yml `projects` 声明 → worktree 落位 + bridge 文件存在(幂等)
+- [x] 会话带 projectId 的 run cwd = worktree(context 不变)
+- [x] 未声明 project 的 run 显式失败,错误可操作
+- [x] detach 清理 worktree + 分支;project 删除被 attach 阻止
+- [x] `grep -rn autoOrchestrate apps/backend/src` 零命中
+- [x] 全仓 typecheck/lint/test 绿 + audit 14/14

--- a/docs/superpowers/specs/2026-08-14-project-worktree-p1-design.md
+++ b/docs/superpowers/specs/2026-08-14-project-worktree-p1-design.md
@@ -1,0 +1,148 @@
+# Project Worktree P1(agent-project 多对多桥接)
+
+- 日期:2026-08-14
+- 状态:已批准(brainstorming 完成;attach 入口 = file-first,run 绑定 = 会话级)
+- 分支:`feat/project-worktree`
+- ADR:`docs/adr/0023-project-worktree-workspace.md`(本 spec 是其 P1 落地)
+
+## 1. 目标与非目标
+
+**目标**
+- agent.yml 声明 `runtime_config.projects: [projectId]`(file-first 多对多)。
+- (agent, project) 对 materialize 一个 git worktree 到 `<agentWs>/projects/<id>/`,共享 bare mirror `<dataDir>/projects/<id>.git`。
+- bridge 把 `.mcp.json` + `.agent/product-tools.json` 写进 worktree(修 product tools 在非默认 cwd 场景的断裂)。
+- conversation 可选携带 projectId;该会话的 run cwd = worktree,context 仍来自 agent workspace。
+- 删除 `autoOrchestrate` 死字段(全链 17 处)。
+
+**非目标(P2)**
+- 输入级 projectId 覆写;合流动作(fast-forward/merge UI);Loop 每 step 浅 clone 切换为常驻 worktree;mirror 定时同步;worktree 悬空 GC。
+
+## 2. 组件
+
+### 2.1 `apps/backend/src/features/project/worktree.ts`(新)
+
+```typescript
+/** Git plumbing for (agent, project) worktrees. All operations are
+ *  idempotent; failures throw with the underlying git stderr. */
+export interface WorktreeProject {
+  readonly projectId: string;
+  readonly repoUrl: string;
+  readonly defaultBranch: string | null;
+}
+
+/** Ensure the shared bare mirror exists and is fresh (clone --mirror on
+ *  first attach; fetch --prune afterwards). Safe under concurrent calls:
+ *  clone writes to `<id>.git.tmp` then renames; a stale .tmp is removed. */
+export function ensureMirror(dataDir: string, project: WorktreeProject): Promise<string>;
+
+/** Ensure the agent's worktree exists at `<agentWs>/projects/<projectId>/`
+ *  on branch `agent/<agentId>/<projectId>` based on the project's
+ *  defaultBranch (mirror HEAD when null). No-op when already present.
+ *  Returns the worktree path. */
+export function ensureWorktree(
+  mirrorPath: string,
+  agentWorkspace: string,
+  project: WorktreeProject,
+  agentId: string,
+): Promise<string>;
+
+/** Detach the worktree and delete its branch (detach path). */
+export function removeWorktree(
+  mirrorPath: string,
+  agentWorkspace: string,
+  project: WorktreeProject,
+  agentId: string,
+): Promise<void>;
+```
+
+- 实现用 `Bun.$`(与 loop-step 的 git 调用同风格),git 二进制即依赖。
+- `ensureWorktree` 的「已存在」判定:`git worktree list --porcelain` 里含该路径即 no-op(不校验分支名,避免误删用户改名后的分支)。
+- 用户自有目录占据 worktree 槽位时:跳过 + 返回 null + 调用方 warn(与 bridge 的「不覆盖用户文件」纪律一致)。
+
+### 2.2 agent-config(多对多声明)
+
+`agentConfigSchema.runtime_config` 增:
+
+```typescript
+projects: z.array(z.string().min(1)).default([]),
+```
+
+- `buildAgentConfig` 的 input/prev 回退与 `serializeAgentYaml`/parse 同步(mcp_servers 同构)。
+- 迁移 0032(手写,`--> statement-breakpoint` 分隔,when 严格递增):`ALTER TABLE conversation ADD COLUMN project_id TEXT REFERENCES project(project_id) ON DELETE RESTRICT;`
+- agent.yml 文件里字段名 `projects`(与 knowledge_packs 命名风格一致,不带 _packs 后缀——它引用的是 project id)。
+
+### 2.3 reconcile(features.ts + workspace-bridge)
+
+`reconcileAgent.fn` 在现有 skills/mcp/knowledge 之后:
+
+```text
+for projectId of agent.config.runtime_config.projects:
+  project = projectSvc.getById(projectId)       // 不存在:console.warn,continue
+  mirror = await ensureMirror(dataDir, project)
+  wtPath = await ensureWorktree(mirror, agent.workspacePath, project, agentId)
+  if (wtPath):
+    writeMcpConfig(wtPath, <与主 workspace 相同的 server 列表>)
+    writeProductToolsManifest(wtPath, <相同 manifest>)
+```
+
+- detach(声明里移除某 project):reconcile 对比上一版(从 DB config 缓存的旧 projects)→ `removeWorktree`。首版用简单差集;缓存缺失时跳过清理(warn)。
+- reconcile 失败永远不炸 agent 更新(与现有 skill/mcp 桥一致:catch + warn)。
+
+### 2.4 conversation 会话级绑定
+
+- 创建 API body 增 `projectId?: string`(校验存在);`ConversationRow`/ports/adapter 跟随。
+- `resolveWorkspace`(features.ts):conversation.projectId 非空时 →
+  1. 查 agent 是否声明该 project(声明 → worktree 路径,`access` 沿用 permission_mode 推导);
+  2. 未声明 → throw(走 dispatch 既有失败路径:run failed + status event 带 error 文案「agent X 未 attach project Y,先在 agent 详情勾选」)。
+- GET /api/conversations/:id 响应带 `projectId`。
+
+### 2.5 死字段删除
+
+`autoOrchestrate` 17 处:schema 列 + select transform + domain 三处 + service create/update/patch + http body + adapter 映射。迁移 0032 同文件内第二条语句 `ALTER TABLE project DROP COLUMN auto_orchestrate;`(与 add 同文件,breakpoint 分隔)。
+
+### 2.6 web
+
+- `/team/[agentId]` 详情:Projects 区(多选 toggle 列表,数据 = listProjects + agent.config.projects;mutation = PATCH projects)。
+- `/chat` 新建会话:可选 project 下拉(有 projectId 时提示「该会话的运行工作区 = project worktree」)。
+- `/team/projects` 行:展示 attach 的 agent 数(查询:遍历 agents 的 config.projects)。
+
+## 3. 数据流
+
+```text
+用户勾选 project(PATCH /api/agents/:id {projects})
+  → agent.yml 重写 + DB 缓存 + reconcile
+  → ensureMirror(首次 clone --mirror)+ ensureWorktree(分支 agent/<a>/<p>)
+  → bridge 写 .mcp.json / .agent/product-tools.json 进 worktree
+创建会话(POST /api/conversations {projectId})
+  → 发消息 → run dispatch → resolveWorkspace
+  → conversation.projectId + agent 已声明 → workspace.root = worktree
+  → child spawn:cwd = worktree,context(skillRoots/prompt/token)仍来自 agent workspace
+```
+
+## 4. 错误处理
+
+| 场景 | 行为 |
+|---|---|
+| attach 时 mirror clone 失败 | PATCH 返回 422(repoUrl/git stderr 摘要);agent.yml 已写入,reconcile 下次重试(warn) |
+| worktree 槽位被用户目录占据 | 跳过 + warn;run 引用该 project 时 preflight 报「worktree 未就绪」 |
+| conversation 引用未声明 project | dispatch 失败路径:run failed + error 文案指明 attach 方法 |
+| 删除 project 仍有 attach | 409 + attach 的 agent 名单;先 detach 再删 |
+| worktree 分支被用户删除 | 下次 reconcile 的 ensureWorktree 重建(git worktree add 分支不存在时 -b 重新创建) |
+
+## 5. 测试
+
+- **worktree.test.ts**:真实 git fixture(repo → mirror → worktree);幂等(双跑无副作用);detach 清理;槽位占据跳过。
+- **reconcile 集成**(workspace-bridge.test.ts 扩展):attach 后 worktree 内 .mcp.json 存在且含 product-tools 条目;重复 reconcile 稳定。
+- **execution**:conversation 带 projectId 的 run,fake daemon 断言 child cwd = worktree 路径;未声明 project 的 run 进 failed 且 error 含指引用语。
+- **config**:projects 字段 round-trip(yaml 写读、PATCH 校验 400)。
+- **E2E 冒烟**:真 repo(本地 file:// 即可)→ attach → 建会话 → 发消息 → 断言 run workspace.root 指向 worktree。
+- **迁移**:fresh-boot 集成测试(现有 db.test 模式)+ autoOrchestrate 列消失断言。
+
+## 6. 验收清单
+
+- [ ] agent.yml `projects` 声明 → worktree 落位 + bridge 文件存在(幂等)
+- [ ] 会话带 projectId 的 run cwd = worktree(context 不变)
+- [ ] 未声明 project 的 run 显式失败,错误可操作
+- [ ] detach 清理 worktree + 分支;project 删除被 attach 阻止
+- [ ] `grep -rn autoOrchestrate apps/backend/src` 零命中
+- [ ] 全仓 typecheck/lint/test 绿 + audit 14/14

--- a/docs/superpowers/specs/2026-08-14-project-worktree-p2-design.md
+++ b/docs/superpowers/specs/2026-08-14-project-worktree-p2-design.md
@@ -152,9 +152,9 @@ cron/手动 → loopStep
 
 ## 7. 验收清单
 
-- [ ] LOOP.md `agent` 字段路由 worktree;无字段 = default 兼容
-- [ ] `grep -rn "dataDir/repos\|resolveRepoPath" apps/backend/src` 零命中
-- [ ] Loop step 在 worktree 上跑通(集成测试,含 rollback)
-- [ ] 聚合页:status/diff/FF/merge 真机走通(本地 file:// repo)
-- [ ] push 开关生效且失败可恢复(422 响应含旧 sha)
-- [ ] 全仓 typecheck/lint/test 绿 + audit 15/14+1 绿
+- [x] LOOP.md `agent` 字段路由 worktree;无字段 = default 兼容
+- [x] `grep -rn "dataDir/repos\|resolveRepoPath" apps/backend/src` 零命中
+- [x] Loop step 在 worktree 上跑通(集成测试,含 rollback)
+- [x] 聚合页:status/diff/FF/merge 真机走通(本地 file:// repo)
+- [x] push 开关生效且失败可恢复(422 响应含旧 sha)
+- [x] 全仓 typecheck/lint/test 绿 + audit 15/14+1 绿

--- a/docs/superpowers/specs/2026-08-14-project-worktree-p2-design.md
+++ b/docs/superpowers/specs/2026-08-14-project-worktree-p2-design.md
@@ -1,0 +1,160 @@
+# Project Worktree P2(Loop worktree 切换 + 合流)
+
+- 日期:2026-08-14
+- 状态:已批准(brainstorming 完成;范围 A+B、LOOP.md 指定 agent、页内 FF+Merge)
+- 分支:`feat/project-worktree`(续 P1)
+- ADR:`docs/adr/0023-project-worktree-workspace.md` §6 P2 行;P1 spec:`2026-08-14-project-worktree-p1-design.md`
+
+## 1. 目标与非目标
+
+**目标**
+- **B(Loop 切换)**:LOOP.md 顶层 `agent: <agentId>`(缺省 `default`);loop 的所有 run 在该 agent 的 (agent, project) worktree 上执行;`resolveRepoPath` 的每 step 浅 clone(`dataDir/repos/`)退役。
+- **A(聚合 + 合流)**:`/team/projects/[id]` 聚合页——attached agents 的分支状态(ahead/behind)、diff 视图、页内 Fast-forward / Merge(可带 push)。
+
+**非目标**
+- PR 流、远端凭证管理(首版限本地/公网可达 repo,ADR 既定)、evaluator 独立分支、worktree GC、输入级 projectId 覆写(P1 已明确后置)。
+
+## 2. B:Loop worktree 切换
+
+### 2.1 LoopConfig 增 agent 字段(packages/loop)
+
+```typescript
+export interface LoopConfig {
+  projectId: string;
+  /** The agent whose (agent, project) worktree runs this loop's steps.
+   *  Empty string = "default" (back-compat). */
+  agent: string;
+  generator: { model: string; systemPrompt: string };
+  // ...(rest unchanged)
+}
+```
+
+- `parseLoopConfig`:`agent: String(frontmatter.agent ?? "default")`;写入侧(loop-service `writeDefaultLoopMd` + create API body)同步加可选 `agent` 字段。
+- `gen.model === eval.model` 等现有校验不动;`agent` 不校验存在性(loop 层无 agent 概念,backend 层负责)。
+
+### 2.2 resolveLoopWorktree(loop-step.ts 替换 resolveRepoPath)
+
+```typescript
+/** Resolve the loop agent's (agent, project) worktree and fast-forward it
+ *  to the project's default branch (clean start per step, mirroring the
+ *  retired per-step clone's semantics). */
+export async function resolveLoopWorktree(
+  loopConfigPath: string,
+  deps: { projectPort: ProjectPort; dataDir: string; agentWorkspaceOf: (agentId: string) => Promise<string | null> },
+): Promise<string | null>
+```
+
+- 读 LOOP.md → `projectId` + `agent`;project 无 repoUrl → throw(现有文案保留)。
+- `agentWorkspaceOf(cfg.agent)` 解析 agent workspace(注入 `agentSvc.getById`;agent 不存在 → throw 指明 `LOOP.md agent "<id>" not found`)。
+- `ensureMirror(dataDir, project)` + `ensureWorktree(mirror, agentWs, project, agentId)`(P1 函数直接复用;worktree 槽位被占 → null → throw 指明)。
+- **每步干净起点**(替换 clone+reset 语义):
+  ```bash
+  git -C <wt> reset --hard refs/heads/<defaultBranch>   # mirror 刚 fetch 过,引用即远端最新
+  ```
+  defaultBranch 空 → `refs/remotes/origin/HEAD` 解析(一次 `git symbolic-ref`,失败则 throw)。
+- 返回 worktree 路径;loopStepImpl 内 `cwd` 全部改用它。**旧 `resolveRepoPath` 函数体删除**(含 `dataDir/repos/` 常量),签名同步改名。
+
+### 2.3 run 绑定与 member 路由
+
+- `ensureLoopScope(conv, genConvId, genMemberId, cfg.agent)`(现在是硬编码 `"default"`,loop-step.ts:390)——evaluator 的 scope 同样用 cfg.agent。
+- `enqueueAndAcquire` 的 `workspace: {root: cwd}` 不变(cwd 已是 worktree)。
+- selective rollback(`git.resetHard` / checkoutFiles / removeFiles)作用于 worktree——函数不动,调用点 cwd 已换。
+
+### 2.4 兼容与迁移
+
+- 存量 LOOP.md 无 `agent` 字段 → 解析为 `"default"`,行为 = P1 的 default agent worktree。**无数据迁移**(旧的 `dataDir/repos/<id>` 目录成为孤儿,不主动删——操作员手动清;bootstrap 打一行 info 提示路径)。
+
+## 3. A:worktree 聚合 + 合流
+
+### 3.1 后端(`features/project/worktree-ops.ts` 新文件 + http.ts 挂路由)
+
+```typescript
+/** Read/merge operations over a project's agent worktrees. All git runs in
+ *  the bare mirror (plumbing) — never in a live worktree (a run may hold it). */
+export function createWorktreeOps(deps: {
+  dataDir: string;
+  projectPort: ProjectPort;
+  listAgentConfigs: () => Promise<Array<{ id: string; workspacePath: string; projects: string[] }>>;
+}): WorktreeOps;
+
+export interface WorktreeStatus {
+  agentId: string;
+  branch: string;                  // agent/<aid>/<pid>
+  ahead: number;                   // vs defaultBranch
+  behind: number;
+  worktreeReady: boolean;          // path exists
+}
+
+export interface WorktreeOps {
+  status(projectId: string): Promise<WorktreeStatus[]>;
+  diff(projectId: string, agentId: string): Promise<string>;   // defaultBranch...branch
+  fastForward(projectId: string, agentId: string, opts: { push: boolean }): Promise<void>;
+  merge(projectId: string, agentId: string, opts: { push: boolean }): Promise<void>;
+}
+```
+
+- **status**:`git -C mirror rev-list --left-right --count <base>...<branch>`;attached agents 从 `listAgentConfigs` 过滤 projects 含 pid。
+- **fast-forward**:先 `rev-list --count <base>..<branch>` 确认 base 无分叉(behind-only)→ `git -C mirror branch -f <defaultBranch> <branch>`;分叉 → 409。
+- **merge**:`git -C mirror merge-tree <base> <branch>` 预检(bare 环境无工作区)——零冲突才 `branch -f`;有冲突 → 409 + 冲突文件列表(merge-tree 输出解析 `+<<<<<<<` 标记)。bare mirror 不支持 `git merge`(无工作区),合流以 branch -f + merge-tree 预检实现,语义 = base 前移到 branch(含合并结果时需先在临时 worktree 真合并——**首版不做真合并**,见 §3.2)。
+- **push**:成功后 `git -C mirror push origin <defaultBranch>`;失败 422 + git stderr 摘要(不回滚本地前移——操作员决定;文案说明)。
+- **错误**:project 无 repoUrl/agent 未 attach → 400/404 系沿用。
+
+### 3.2 合流语义的诚实边界(写进 API 文档注释)
+
+`branch -f` 只做「base 移到 branch tip」。两个 agent 分支各有新提交时(base 同时 behind 两者),谁的 branch 都不能直接 -f——**真两方合并首版不做**。merge 端点此时返回 409 `diverged; merge both branches manually`。页内 Merge 按钮仅在「单分支领先」场景可用(与 FF 等价);这是产品简化,不是实现偷懒,升级路径:临时 worktree 真合并后 -f。
+
+### 3.3 HTTP(挂 project http.ts)
+
+```
+GET  /api/projects/:id/worktrees                     → { worktrees: WorktreeStatus[] }
+GET  /api/projects/:id/worktrees/:agentId/diff       → { diff: string }
+POST /api/projects/:id/worktrees/:agentId/fast-forward  body { push?: boolean }
+POST /api/projects/:id/worktrees/:agentId/merge         body { push?: boolean }
+```
+
+### 3.4 前端 `/team/projects/[id]` 聚合页
+
+- 头部:project 信息(name/repoUrl/defaultBranch)+ 该 project 的 Loops 列表(现有 loop 列表过滤 projectId)。
+- 主体:worktree 卡(复用 ListRowCard)——agent 名、分支 mono、ahead/behind 徽章(仅 ahead>0 时亮 ok 色)、worktreeReady 警示、展开 diff(前 200 行 + 截断提示)、FF/Merge 按钮(confirm 走现有 confirm 模式 + push checkbox)。
+- 空态:无 attached agents → EmptyState 指向 agent 详情页。
+- `/team/projects` 列表行加「N agents」徽章 + 点击进聚合页。
+
+## 4. 数据流(Loop 一步)
+
+```text
+cron/手动 → loopStep
+  → parseLoopConfig: projectId + agent
+  → resolveLoopWorktree: mirror(ensure) → worktree(ensure) → reset --hard <default>
+  → Generator run: cwd=worktree, context=agent workspace
+  → Evaluator run: 同 worktree 只读
+  → verdict → selective rollback(resetHard/checkoutFiles 于 worktree)
+聚合页 → status/diff(读 mirror)→ FF/Merge(bare 内 branch -f + 可选 push)
+```
+
+## 5. 错误处理
+
+| 场景 | 行为 |
+|---|---|
+| LOOP.md agent 不存在 | loopStep throw,现有 scheduler 重试/告警路径 |
+| worktree 槽位被占 | throw 指明路径;聚合页 worktreeReady=false 警示 |
+| FF 时 base 已分叉 | 409 `diverged` |
+| merge-tree 报冲突 | 409 + 冲突文件列表 |
+| push 失败 | 422 + stderr 摘要;本地 base 已前移,文案说明如何手动回退(`branch -f <base> <旧sha>`,响应附旧 sha) |
+| reset --hard 失败(脏 worktree 被外进程锁) | loopStep throw → 现有重试 |
+
+## 6. 测试
+
+- **resolveLoopWorktree**(真 git fixture):agent 字段路由到对应 agentWs;default 兼容;每步 reset(defaultBranch 引用);agent 不存在 throw;旧 clone 路径不再产生。
+- **worktree-ops**(真 git fixture):status 计数;FF 成功/分叉 409;merge 冲突 409 + 文件列表;push 开关(mock origin = 本地 file:// repo)。
+- **loop-step 集成**:现有测试的 repo fixture 改为 worktree 路径断言;rollback 语义回归(baseSha reset)。
+- **HTTP**:四端点 happy path + 409/422(沿用 project http 测试模式)。
+- **前端**:audit 断言一条 `/team/projects/[id]` 渲染 worktree 卡容器。
+
+## 7. 验收清单
+
+- [ ] LOOP.md `agent` 字段路由 worktree;无字段 = default 兼容
+- [ ] `grep -rn "dataDir/repos\|resolveRepoPath" apps/backend/src` 零命中
+- [ ] Loop step 在 worktree 上跑通(集成测试,含 rollback)
+- [ ] 聚合页:status/diff/FF/merge 真机走通(本地 file:// repo)
+- [ ] push 开关生效且失败可恢复(422 响应含旧 sha)
+- [ ] 全仓 typecheck/lint/test 绿 + audit 15/14+1 绿

--- a/packages/loop/src/state-md.test.ts
+++ b/packages/loop/src/state-md.test.ts
@@ -519,3 +519,26 @@ describe("parseLoopConfig", () => {
     expect(parseLoopConfig("# Hello")).toBeNull();
   });
 });
+
+describe("parseLoopConfig agent field (ADR 0023 P2)", () => {
+  const base = [
+    "---",
+    "projectId: proj-x",
+    "generator:",
+    "  model: claude-sonnet-4",
+    "  systemPrompt: fix",
+    "evaluator:",
+    "  model: claude-opus-4",
+    "  systemPrompt: verify",
+  ];
+
+  test("reads the agent field when present", () => {
+    const cfg = parseLoopConfig([...base, "agent: coder-1", "---"].join("\n"));
+    expect(cfg?.agent).toBe("coder-1");
+  });
+
+  test("defaults to default for back-compat", () => {
+    const cfg = parseLoopConfig([...base, "---"].join("\n"));
+    expect(cfg?.agent).toBe("default");
+  });
+});

--- a/packages/loop/src/state-md.ts
+++ b/packages/loop/src/state-md.ts
@@ -303,6 +303,9 @@ export function parseVerdictMd(md: string): Verdict | null {
 
 export interface LoopConfig {
   projectId: string;
+  /** The agent whose (agent, project) worktree runs this loop's steps
+   *  (ADR 0023 P2). Empty string = "default" (back-compat). */
+  agent: string;
   generator: { model: string; systemPrompt: string };
   evaluator: { model: string; systemPrompt: string };
   acceptance: string;
@@ -339,6 +342,7 @@ export function parseLoopConfig(md: string): LoopConfig | null {
 
   return {
     projectId: String(frontmatter.projectId ?? ""),
+    agent: String(frontmatter.agent ?? "default") || "default",
     generator: {
       model: String(gen.model),
       systemPrompt: String(gen.systemPrompt ?? ""),


### PR DESCRIPTION
## Summary

Implements ADR 0023 end to end: Project and Agent become many-to-many through per-(agent, project) git worktrees. Context (persona/skills/knowledge, product tools) stays in the agent workspace; the cwd moves to the worktree.

**P1 — binding**
- `agent.yml` `runtime_config.projects` (file-first) + PATCH validation
- Shared bare mirror `<dataDir>/projects/<id>.git` + worktree `<agentWs>/projects/<id>/` on branch `agent/<agentId>/<projectId>`; bridge writes `.mcp.json` + product-tools manifest into the worktree
- Conversation-level `projectId` (FK RESTRICT): runs use the worktree as cwd; unattached = explicit actionable failure
- Migration 0032 (breakpoint-separated); dead `auto_orchestrate` dropped (17 refs)
- Web: agent detail Projects tab (attach/detach), new-chat project select; project delete refused (409) while attached

**P2 — loop switch + merge ops**
- LOOP.md `agent` field (default-compat) routes the worktree owner and loop scope members; the per-step shallow clone is retired (`reset --hard` to the default branch per step)
- Worktree ops (all plumbing inside the mirror, live worktrees never touched): status (ahead/behind), diff, fast-forward, merge — diverged/conflicts are honest 409s
- Web `/team/projects/[id]` aggregate: worktree cards (agent names, ahead/behind, lazily-fetched diff, FF/Merge with confirm + optional push), linked loops

**Landing-review fixes** (reviewer + live regression found):
- mirror fetch was a no-op (mirror clones have no refs/remotes namespace) → ff-only base refresh
- mirror pushes were impossible (`remote.origin.mirror=true`) and a failed push left the base half-moved → per-invocation config override + rollback to the previous tip
- review actions reset worktrees a live run may hold → worktree resolution moved to the generator path only
- same-root dispatches race → workspace-root mutex in the execution service
- loop products never reached the branch (model told not to commit + per-step reset) → PASS verdicts commit onto the agent branch (ahead>0, mergeable)
- detach left worktrees + branches behind → update-hook diff removes both
- ListRowCard rendered a false "Offline" pill on every page → conditional render

## Test plan

- [x] Worktree plumbing: real-git fixtures (mirror idempotency, branch naming, slot protection, detach)
- [x] Mirror freshness regressions: origin advance picked up; agent branches survive refresh
- [x] Push round-trip regression (real origin); diverged refusal keeps the base intact
- [x] Execution: conversation-bound runs land cwd=worktree; unattached fails with guidance; same-root serialization
- [x] Loop integration (real coding-agent child): worktree paths, PASS commit on the agent branch
- [x] Full gates: typecheck 42/42, test 42/42, lint 23/23; audit 15/15
- [x] **Live end-to-end regression** (fresh repo): attach → materialize → remote-advance refresh → two agents isolated on one project → merge+push lands on origin → detach cleans both worktree and branch → review does not reset → aggregate page renders names/status/links

Specs: `docs/superpowers/specs/2026-08-14-project-worktree-p1-design.md`, `...-p2-design.md` · ADR: `docs/adr/0023-project-worktree-workspace.md`